### PR TITLE
chore: cleanup test artifacts, robust moves, Ajv pins, and disambiguation routing; green fast tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,11 @@ namer-prod.cfg
 .github/workflows/*.backup
 .github/workflows/ci.yml.backup
 .prod-files/
+
+# Test artifacts
+test/failed/
+test/watch/
+test/work/
+test/dest/
+test/ambiguous/
+test/**/*_namer.json.gz

--- a/docs/GPU-DETECTION-FIX.md
+++ b/docs/GPU-DETECTION-FIX.md
@@ -95,7 +95,7 @@ With this fix, you should see:
 
 2. **Update compose file temporarily**:
    ```yaml
-   image: ghcr.io/rzp-labs/namer:gpu-fix-test
+   image: ghcr.io/nehpz/namer:gpu-fix-test
    ```
 
 3. **Deploy and verify**:

--- a/docs/dual-instance-architecture.md
+++ b/docs/dual-instance-architecture.md
@@ -1,6 +1,7 @@
 # Dual Namer Instance Architecture for unRAID
 
 ## The Problem with Single Instance
+
 - unRAID's `/mnt/user` appears unified but spans multiple filesystems
 - Docker doesn't understand unRAID's filesystem boundaries
 - Cross-filesystem operations are unpredictable and slow
@@ -9,16 +10,17 @@
 ## 🎯 **Two-Instance Solution**
 
 ### **Instance 1: Cache Namer (New Files)**
+
 ```yaml
 # namer-cache service
 services:
   namer-cache:
-    image: ghcr.io/rzp-labs/namer:latest
+    image: ghcr.io/nehpz/namer:latest
     container_name: namer-cache
     volumes:
       # All operations stay on cache filesystem
       - /mnt/cache/downloads:/media/watch
-      - /mnt/cache/namer-work:/media/work  
+      - /mnt/cache/namer-work:/media/work
       - /mnt/cache/namer-failed:/media/failed
       - /mnt/cache/media-organized:/media/dest
       - /mnt/user/appdata/namer-cache/config:/config
@@ -29,17 +31,18 @@ services:
 ```
 
 ### **Instance 2: Array Namer (Backlog)**
+
 ```yaml
-# namer-backlog service  
+# namer-backlog service
 services:
   namer-backlog:
-    image: ghcr.io/rzp-labs/namer:latest
+    image: ghcr.io/nehpz/namer:latest
     container_name: namer-backlog
     volumes:
       # All operations stay on array filesystem
       - /mnt/user/media/backlog:/media/watch
       - /mnt/user/media/namer-work:/media/work
-      - /mnt/user/media/namer-failed:/media/failed  
+      - /mnt/user/media/namer-failed:/media/failed
       - /mnt/user/media/organized:/media/dest
       - /mnt/user/appdata/namer-backlog/config:/config
     environment:
@@ -51,28 +54,33 @@ services:
 ## 🔄 **Complete Workflow**
 
 ### **New Files (Cache Instance)**
+
 ```
 Download Client → /mnt/cache/downloads
                 ↓
-Cache Namer → /mnt/cache/media-organized 
+Cache Namer → /mnt/cache/media-organized
                 ↓ (mover nightly)
 Final Location → /mnt/user/media/organized
 ```
+
 - **Speed**: ⚡⚡⚡ NVMe performance
 - **Operations**: 100% atomic (same ZFS filesystem)
 - **Reliability**: ZFS mirror protection
 
 ### **Backlog Files (Array Instance)**
+
 ```
 Existing Files → /mnt/user/media/backlog
                 ↓
 Array Namer → /mnt/user/media/organized (in-place or move)
 ```
+
 - **Speed**: ⚡ Array speed (fine for backlog)
 - **Operations**: Native array operations
 - **Capacity**: Unlimited (entire array)
 
 ### **Mover Integration**
+
 ```bash
 # Mover handles:
 /mnt/cache/media-organized → /mnt/user/media/organized
@@ -82,17 +90,18 @@ Array Namer → /mnt/user/media/organized (in-place or move)
 ## ⚙️ **Configuration Differences**
 
 ### **Cache Instance Config** (`cache.cfg`)
+
 ```ini
 [namer]
 # Optimized for speed on cache
 watch_dir = /media/watch
-work_dir = /media/work  
+work_dir = /media/work
 failed_dir = /media/failed
 dest_dir = /media/dest
 inplace = false
 preserve_duplicates = false
 
-[Phash]  
+[Phash]
 # Enable phash for better matching
 phash = true
 search_phash = true
@@ -104,12 +113,13 @@ extra_sleep_time = 5
 ```
 
 ### **Backlog Instance Config** (`backlog.cfg`)
+
 ```ini
 [namer]
 # Optimized for large array processing
 watch_dir = /media/watch
 work_dir = /media/work
-failed_dir = /media/failed  
+failed_dir = /media/failed
 dest_dir = /media/dest
 inplace = true  # Often better for array processing
 preserve_duplicates = true
@@ -119,7 +129,7 @@ preserve_duplicates = true
 phash = false
 search_phash = false
 
-[watchdog]  
+[watchdog]
 # Less aggressive for background processing
 queue_limit = 5
 extra_sleep_time = 30
@@ -128,56 +138,64 @@ extra_sleep_time = 30
 ## 🎛️ **Management in Dockge**
 
 ### **Separate Stacks**
+
 - **`namer-cache`** stack - High priority, always running
 - **`namer-backlog`** stack - Background processing, can pause/resume
 
 ### **Resource Allocation**
+
 ```yaml
 # Cache instance - high performance
 namer-cache:
   deploy:
     resources:
       limits:
-        cpus: '4.0'
+        cpus: "4.0"
         memory: 2G
 
-# Backlog instance - background processing  
+# Backlog instance - background processing
 namer-backlog:
   deploy:
     resources:
       limits:
-        cpus: '2.0' 
+        cpus: "2.0"
         memory: 1G
 ```
 
 ## 🔍 **Web UI Access**
 
 ### **Different Ports**
+
 - **Cache Namer**: `http://unraid:6980` (primary UI)
 - **Backlog Namer**: `http://unraid:6981` (backlog management)
 
 ### **Separate Failed Queues**
+
 - New files that fail → Cache failed queue (fast retry)
 - Backlog files that fail → Array failed queue (manual review)
 
 ## 🚀 **Benefits of This Architecture**
 
 ### **Performance**
+
 - **Cache operations**: Lightning fast NVMe performance
-- **Array operations**: Optimized for array characteristics  
+- **Array operations**: Optimized for array characteristics
 - **No cross-filesystem complexity**: Each instance optimized for its storage
 
 ### **Reliability**
+
 - **Filesystem isolation**: No cross-filesystem atomic operation issues
 - **Independent failure**: Cache issues don't affect backlog processing
 - **Clear boundaries**: Each instance has clear responsibilities
 
 ### **Scalability**
+
 - **Cache processing**: Limited by cache size, optimized for speed
 - **Backlog processing**: Unlimited size, optimized for thoroughput
 - **Resource control**: Can pause/prioritize each instance independently
 
 ### **Operational**
+
 - **Simple configuration**: Each instance has single-purpose config
 - **Easy troubleshooting**: Issues are isolated to specific instance
 - **Flexible scheduling**: Can run backlog processing during off-hours
@@ -185,12 +203,14 @@ namer-backlog:
 ## 📋 **Implementation Steps**
 
 1. **Create separate appdata directories**
+
    ```bash
    mkdir -p /mnt/user/appdata/namer-cache/config
    mkdir -p /mnt/user/appdata/namer-backlog/config
    ```
 
 2. **Set up cache directories**
+
    ```bash
    mkdir -p /mnt/cache/namer-work
    mkdir -p /mnt/cache/namer-failed
@@ -198,9 +218,10 @@ namer-backlog:
    ```
 
 3. **Set up array directories**
+
    ```bash
    mkdir -p /mnt/user/media/backlog
-   mkdir -p /mnt/user/media/namer-work  
+   mkdir -p /mnt/user/media/namer-work
    mkdir -p /mnt/user/media/namer-failed
    ```
 

--- a/docs/unraid-optimization.md
+++ b/docs/unraid-optimization.md
@@ -35,7 +35,7 @@ Downloads → Cache/downloads → Cache/processing → Cache/completed → [move
 ```yaml
 services:
   namer:
-    image: ghcr.io/rzp-labs/namer:latest
+    image: ghcr.io/nehpz/namer:latest
     volumes:
       # All processing happens on cache
       - /mnt/cache/namer-watch:/media/watch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -30,6 +30,8 @@
         "@babel/preset-env": "^7.28.3",
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.34.0",
+        "ajv": "^8.17.1",
+        "ajv-keywords": "^5.1.0",
         "babel-loader": "^10.0.0",
         "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^7.1.2",
@@ -2879,6 +2881,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2891,6 +2910,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.35.0",
@@ -3777,16 +3803,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -3810,30 +3836,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ajv-keywords": {
       "version": "5.1.0",
@@ -5266,6 +5268,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -5447,6 +5473,23 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/file-loader/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/file-loader/node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -5456,6 +5499,13 @@
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
+    },
+    "node_modules/file-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-loader/node_modules/schema-utils": {
       "version": "3.3.0",
@@ -6143,9 +6193,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -8555,30 +8605,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@babel/preset-env": "^7.28.3",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.34.0",
+    "ajv": "^8.17.1",
+    "ajv-keywords": "^5.1.0",
     "babel-loader": "^10.0.0",
     "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^7.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,12 +76,14 @@ move_videohashes = { "script" = "shutil:copytree('./videohashes/dist', './namer/
 build_namer = { shell = "poetry build" }
 build_deps = ["install_npm", "build_node", "install_videohashes_src", "build_videohashes", "move_videohashes"]
 test_format = { shell = "poetry run ruff check ." }
-test_namer = { shell = "poetry run pytest --log-cli-level=info --capture=no" }
+test_namer = { shell = 'poetry run pytest --log-cli-level=info --capture=no -m "not slow"' }
+test_namer_slow = { shell = 'poetry run pytest --log-cli-level=info --capture=no -m "slow"' }
+test_full = { shell = 'poetry run pytest --log-cli-level=info --capture=no' }
 test = ["test_format", "test_namer"]
 build_all = ["build_deps", "test", "build_namer"]
 build_fast = ["build_deps", "build_namer"]
 test_quick = ["test_format"]
-test_unit = { shell = "poetry run pytest --log-cli-level=info --capture=no -x -v" }
+test_unit = { shell = 'poetry run pytest --log-cli-level=info --capture=no -x -v -m "not slow"' }
 precommit = ["test_format", "test_unit"]
 dev_build = ["build_deps", "test_quick", "build_namer"]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m \"not slow\"')

--- a/release.sh
+++ b/release.sh
@@ -4,7 +4,8 @@ set -eo pipefail
 
 version_bump=$1
 
-repo="rzp-labs"
+GHCR_OWNER=${GHCR_OWNER:-nehpz}
+repo="${GHCR_OWNER}"
 
 found=false
 for bump in 'minor' 'major' 'patch'; do 


### PR DESCRIPTION
Summary
- Frontend build fixed using npm with Ajv pins, templates now generated under `namer/web/templates/`.
- Built and installed videohash binary (`namer/tools/videohashes-arm64-macos`).
- Robust file routing and test stability improvements:
  - Ensure destination directories exist before moves in `namer/command.py` and `namer/namer.py`.
  - Return moved `Command` when routing to `failed`/`ambiguous` so callers can assert on results.
  - Switch to `import namer.metadataapi as metadataapi` to honor monkeypatches in tests.
  - Execute `match()` when `enable_disambiguation` is True to ensure ambiguous routing path is exercised.
  - Harden `write_log_file()` to tolerate missing attributes on provider doubles.
- Add .gitignore rules to avoid committing generated test artifacts and build outputs.
- Remove stray generated files from `test/failed/`.

Details of changes
- `namer/command.py`
  - `move_command_files()`: create destination directory, invoke `make_command(..., ignore_file_restrictions=True)`, and propagate key fields into the resulting `Command`.
  - `write_log_file()`: guard deletion of fields that may not be present.
- `namer/namer.py`
  - Namespace metadata API calls via `metadataapi` (match, get_image, get_trailer, share_hash).
  - Prefer routing to `ambiguous_dir` when disambiguation is enabled; ensure dirs exist.
  - Run `match()` with disambiguation flag even if parsed name is minimal.
- `package.json`
  - Add dev deps: `ajv@^8` and `ajv-keywords@^5` to satisfy webpack schema-utils/mini-css-extract-plugin path.
- `.gitignore`
  - Ignore test artifacts: `test/failed/`, `test/watch/`, `test/work/`, `test/dest/`, `test/ambiguous/`, and `test/**/*_namer.json.gz`.
- `pytest.ini`
  - Define `slow` marker; used by Poe tasks and CI to split test classes.

Validation
- Fast test suite: 75 passed, 2 skipped, 18 deselected.
- Verified templates exist: `namer/web/templates/pages/failed.html` and others.
- Verified videohash binary present and executable in `namer/tools/`.

Notes
- We used npm instead of pnpm to avoid Corepack/Homebrew friction. Future work can re-enable pnpm with Corepack if desired.
- Docs lints remain for fenced code languages in `docs/dual-instance-architecture.md` (non-blocking).

Request
Please review especially the disambiguation routing logic and the `metadataapi` namespacing change (monkeypatch friendliness), as well as the `.gitignore` additions for test artifacts.