### PR TITLE
ci: bump actions/setup-python to v6 and actions/checkout to v5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v6 # bump to v6 (Dependabot)
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Summary
- Update GitHub Actions versions to current stable:
  - actions/setup-python → v6
  - actions/checkout → v5

Files
- .github/workflows/claude.yml: checkout v5
- .github/workflows/claude-code-review.yml: checkout v5
- .github/workflows/release-bump.yml: setup-python v6

Rationale
- Keeps CI up to date with latest security fixes and features, aligns with Dependabot PRs.

Validation
- CI expected to be unaffected functionally; jobs should continue to run as before.