### PR TITLE
ci: grant write perms for PR/issues; enable Claude comment fallback

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     
     steps:


### PR DESCRIPTION
This PR updates the Claude Code Review workflow to:

- Grant write permissions for pull-requests and issues so comments can be posted
- Keep the new fallback step that posts the formatted review from $GITHUB_STEP_SUMMARY via `gh pr comment`

Once merged into main, PR runs will use these settings (GitHub uses the base branch workflow for pull_request events). Re-run the "Claude Code Review" job on open PRs to get a posted comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-review automation permissions to allow writing to pull requests and issues; other permissions remain unchanged.
  * No modifications to workflow logic or steps.
  * No user-facing changes or impact to product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->