### PR TITLE
CI: Add PR validation (ruff+pytest) and container smoke test (amd64)

### DIFF
--- a/.github/workflows/pr-container-smoke.yml
+++ b/.github/workflows/pr-container-smoke.yml
@@ -1,0 +1,58 @@
+name: PR Container Smoke
+
+on:
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: pr-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke:
+    name: Build (amd64) and healthcheck container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (amd64, load locally)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: nehpz/namer:pr-${{ github.sha }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start container
+        run: |
+          docker run -d --name namer \
+            -e NAMER_CONFIG=/config/namer.cfg \
+            -p 6980:6980 \
+            -v "${{ github.workspace }}/config:/config:ro" \
+            nehpz/namer:pr-${{ github.sha }}
+          # Give it a moment to start
+          sleep 15
+
+      - name: Healthcheck
+        run: |
+          curl -sf http://127.0.0.1:6980/api/healthcheck
+
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          docker logs namer || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f namer || true

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,63 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: pr-validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Lint and Test (Poetry)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: |
+          pipx install poetry
+
+      - name: Cache Poetry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          poetry --version
+          poetry install
+
+      - name: Ruff check
+        run: poetry run ruff check .
+
+      - name: Pytest with coverage
+        run: poetry run pytest --cov --junitxml=pytest-junit.xml --cov-report=xml
+
+      - name: Upload coverage.xml
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+      - name: Upload junit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-junit
+          path: pytest-junit.xml


### PR DESCRIPTION
Summary
- Add two PR workflows to harden CI and fail earlier with clear signals.
  - .github/workflows/pr-validate.yml: Lint (ruff) + unit tests (pytest) with Poetry caching.
  - .github/workflows/pr-container-smoke.yml: Build amd64 image with Buildx, start container, and healthcheck.

Details
- Validation job
  - Caches Poetry to reduce PR latency
  - Publishes coverage.xml and junit result as artifacts for review
- Container smoke
  - Uses docker/build-push-action@v6 with GHA cache
  - Loads amd64 image locally and verifies the healthcheck endpoint
  - Uploads container logs on failure for easier triage

Notes
- This PR does not alter release workflows or multi-arch builds.
- Next steps (tracked in issues): multi-arch push with platform smoke on main; static/security scans; artifact uploads on failures; required checks & concurrency guardrails.

Rationale
- These jobs catch common regressions (lint, unit tests, startup issues) before merging and align with our local pre-commit/pre-push improvements.
