### PR TITLE
DevX: adopt Python pre-commit hooks and pre-push validate (--fast)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
     groups:
       minor-and-patch:
         update-types:
@@ -29,6 +32,14 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Dockerfiles
   - package-ecosystem: "docker"
@@ -39,6 +50,14 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Node (for web assets tooling in package.json)
   - package-ecosystem: "npm"
@@ -49,3 +68,11 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/pr-container-smoke.yml
+++ b/.github/workflows/pr-container-smoke.yml
@@ -1,0 +1,64 @@
+name: PR Container Smoke
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke:
+    name: Build (amd64) and healthcheck container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        # actions/checkout@v4 pinned to commit SHA
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        # docker/setup-buildx-action@v3 pinned to commit SHA
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
+      - name: Build image (amd64, load locally)
+        # docker/build-push-action@v6 pinned to commit SHA
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: nehpz/namer:pr-${{ github.sha }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start container
+        run: |
+          docker run -d --name namer \
+            -e NAMER_CONFIG=/config/namer.cfg \
+            -p 6980:6980 \
+            -v "${{ github.workspace }}/config:/config:ro" \
+            nehpz/namer:pr-${{ github.sha }}
+          # Give it a moment to start
+          sleep 15
+
+      - name: Healthcheck
+        run: |
+          curl -sf http://127.0.0.1:6980/api/healthcheck
+
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          docker logs namer || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f namer || true

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,71 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Lint and Test (Poetry)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # actions/checkout@v4 pinned to commit SHA
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        # actions/setup-python@v5 pinned to commit SHA
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: |
+          pipx install poetry
+
+      - name: Cache Poetry
+        # actions/cache@v4 pinned to commit SHA
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          poetry --version
+          poetry install
+
+      - name: Ruff check
+        run: poetry run ruff check .
+
+      - name: Pytest with coverage
+        run: poetry run pytest --cov --junitxml=pytest-junit.xml --cov-report=xml
+
+      - name: Upload coverage.xml
+        if: always()
+        # actions/upload-artifact@v4 pinned to commit SHA
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+      - name: Upload junit report
+        if: always()
+        # actions/upload-artifact@v4 pinned to commit SHA
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: pytest-junit
+          path: pytest-junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,6 @@ namer/web/templates
 namer/tools
 .flakeheaven_cache
 .ruff_cache
-scripts/
-!scripts/install-intel-firmware-fast.sh
-!scripts/detect-intel-gpu.sh
-test_dirs/
 database/
 .pytest_cache/
 test_config.cfg

--- a/.husky/pre-commit.bak
+++ b/.husky/pre-commit.bak
@@ -1,1 +1,0 @@
-pnpm lint-staged -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+
+  # Shell linting for our scripts
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        files: ^(scripts/|docker-entrypoint-user.sh)
+        types: [shell]
+
+  # Optional Dockerfile linting (non-blocking at first; set `--failure-threshold` to `warning`)
+  - repo: local
+    hooks:
+      - id: hadolint
+        name: hadolint
+        entry: bash -lc 'command -v hadolint >/dev/null 2>&1 && hadolint Dockerfile || echo "hadolint not installed; skipping"'
+        language: system
+        pass_filenames: false
+        files: ^Dockerfile$
+
+  # Run validate fast on pre-push
+  - repo: local
+    hooks:
+      - id: validate-fast
+        name: validate.sh --fast (pre-push)
+        entry: ./validate.sh --fast
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ SCRIPT_DIR = ./scripts
 
 .PHONY: all help build build-fast build-full build-dev \
         build-amd64 build-arm64 build-multiarch ensure-builder \
-        test test-basic test-integration validate clean clean-deep config
+        test test-basic test-integration validate clean clean-deep config \
+        setup-dev
 
 help: ## Show available targets
 	@echo "🏗️  Namer Build System"
@@ -119,10 +120,14 @@ release-prep: validate build-full test-integration ## Full release preparation
 
 # Docker operations (using native commands)
 push: ## Push built image to registry
-	@echo "📤 Pushing $(IMAGE_NAME):$(VERSION)..."
 	@docker push $(IMAGE_NAME):$(VERSION)
 	@docker push $(IMAGE_NAME):latest
 
 pull: ## Pull image from registry
-	@echo "📥 Pulling $(IMAGE_NAME):$(VERSION)..."
+	@echo "Pulling $(IMAGE_NAME):$(VERSION)..."
 	@docker pull $(IMAGE_NAME):$(VERSION)
+
+# Developer setup
+setup-dev: ## Install local hooks (pre-commit + pre-push) for fast checks and validation
+	@chmod +x scripts/install-hooks.sh || true
+	@./scripts/install-hooks.sh

--- a/namer/__main__.py
+++ b/namer/__main__.py
@@ -97,50 +97,50 @@ def main():
 def clear_hash_cache(arg_list):
     """Clear cached hashes for files matching a pattern."""
     if len(arg_list) == 0:
-        print("Usage: namer clear-cache <filename_pattern>")
-        print("Example: namer clear-cache tushy.23.04.16.azul.hermosa")
+        print('Usage: namer clear-cache <filename_pattern>')
+        print('Example: namer clear-cache tushy.23.04.16.azul.hermosa')
         return
-    
+
     filename_pattern = arg_list[0]
     config = default_config()
-    
+
     if not config.use_database:
-        print("❌ Database is not enabled in configuration")
+        print('❌ Database is not enabled in configuration')
         return
-    
+
     db_file = config.database_path / 'namer_database.sqlite'
     if not db_file.exists():
-        print("❌ Database file does not exist")
+        print('❌ Database file does not exist')
         return
-    
+
     try:
         # Database should already be bound from main(), but ensure it's bound
         if not db.provider:
             db.bind(provider='sqlite', filename=str(db_file), create_db=False)
             db.generate_mapping()
-        
+
         with db_session:
             # Find files matching the filename pattern
             files = select(f for f in File if filename_pattern.lower() in f.file_name.lower())[:]
-            
+
             if not files:
-                print(f"❌ No cached entries found for filename containing: {filename_pattern}")
+                print(f'❌ No cached entries found for filename containing: {filename_pattern}')
                 return
-            
-            print(f"🔍 Found {len(files)} cached entries:")
+
+            print(f'🔍 Found {len(files)} cached entries:')
             for f in files:
-                print(f"   📁 {f.file_name} (size: {f.file_size}, phash: {f.phash})")
-            
+                print(f'   📁 {f.file_name} (size: {f.file_size}, phash: {f.phash})')
+
             # Delete the entries
             for f in files:
                 f.delete()
-                print(f"🗑️  Deleted cache entry for: {f.file_name}")
-            
-            print("✅ Cache cleared successfully!")
-            print("🔄 Next processing will recalculate hash with format consistency fixes")
-            
+                print(f'🗑️  Deleted cache entry for: {f.file_name}')
+
+            print('✅ Cache cleared successfully!')
+            print('🔄 Next processing will recalculate hash with format consistency fixes')
+
     except Exception as e:
-        print(f"❌ Error clearing cache: {e}")
+        print(f'❌ Error clearing cache: {e}')
 
 
 if __name__ == '__main__':

--- a/namer/configuration.py
+++ b/namer/configuration.py
@@ -591,18 +591,22 @@ class NamerConfig:
             token = 'None is Set, Go to https://theporndb.net/register to get one!'
             if self.porndb_token:
                 token = '*' * len(self.porndb_token)
-            info.update({
-                'porndb_token': token,
-                'override_tpdb_address': self.override_tpdb_address,
-            })
+            info.update(
+                {
+                    'porndb_token': token,
+                    'override_tpdb_address': self.override_tpdb_address,
+                }
+            )
         elif provider == 'stashdb':
             token = 'None is Set, Get token from StashDB settings!'
             if self.stashdb_token:
                 token = '*' * len(self.stashdb_token)
-            info.update({
-                'stashdb_token': token,
-                'stashdb_endpoint': self.stashdb_endpoint,
-            })
+            info.update(
+                {
+                    'stashdb_token': token,
+                    'stashdb_endpoint': self.stashdb_endpoint,
+                }
+            )
         else:
             info.update({'provider_config': f'Unknown provider: {self.metadata_provider}'})
 

--- a/namer/configuration_utils.py
+++ b/namer/configuration_utils.py
@@ -123,21 +123,15 @@ def __verify_dir(config: NamerConfig, name: str, other_dirs: List[str]) -> bool:
             # Allow non-existent ambiguous_dir (it will be created at runtime),
             # but still forbid nesting within other watchdog directories.
             if is_nested:
-                logger.error(
-                    f'Configured directory {name}: "{dir_name}" must not be inside another watchdog directory'
-                )
+                logger.error(f'Configured directory {name}: "{dir_name}" must not be inside another watchdog directory')
                 return False
             if exists and not dir_name.is_dir():
-                logger.error(
-                    f'Configured directory {name}: "{dir_name}" exists but is not a directory'
-                )
+                logger.error(f'Configured directory {name}: "{dir_name}" exists but is not a directory')
                 return False
         else:
             # For all other watchdog dirs, require existing directory and no nesting
             if (not dir_name.is_dir()) or is_nested:
-                logger.error(
-                    f'Configured directory {name}: "{dir_name}" is not a directory or is inside another watchdog directory'
-                )
+                logger.error(f'Configured directory {name}: "{dir_name}" is not a directory or is inside another watchdog directory')
                 return False
 
         # work_dir should be empty only if it exists
@@ -150,9 +144,7 @@ def __verify_dir(config: NamerConfig, name: str, other_dirs: List[str]) -> bool:
 
         # Warn about permissions only when the path exists
         if exists and not os.access(dir_name, os.W_OK):
-            logger.warning(
-                f'Configured directory {name}: "{dir_name}" might have write permission problem'
-            )
+            logger.warning(f'Configured directory {name}: "{dir_name}" might have write permission problem')
 
     return True
 
@@ -187,13 +179,13 @@ def __verify_metadata_provider_config(config: NamerConfig) -> bool:
     Verify metadata provider configuration settings.
     """
     success = True
-    
+
     # Validate provider selection
     supported_providers = ['theporndb', 'stashdb']
     if config.metadata_provider.lower() not in supported_providers:
         logger.error(f'Unsupported metadata provider: "{config.metadata_provider}". Supported: {supported_providers}')
         success = False
-    
+
     # Only validate provider-specific settings if directories are configured (indicates real usage vs test)
     if hasattr(config, 'watch_dir') or hasattr(config, 'dest_dir') or hasattr(config, 'work_dir'):
         # Validate provider-specific settings for real configurations
@@ -209,7 +201,7 @@ def __verify_metadata_provider_config(config: NamerConfig) -> bool:
             # Endpoint is built-in; override is optional and primarily used by advanced deployments
             if not config.stashdb_endpoint or config.stashdb_endpoint.strip() == '':
                 logger.info('Using default StashDB endpoint; stashdb_endpoint not set')
-            
+
             if not config.stashdb_token or config.stashdb_token.strip() == '':
                 logger.warning('StashDB provider works better with an API token (stashdb_token)')
     else:
@@ -218,7 +210,7 @@ def __verify_metadata_provider_config(config: NamerConfig) -> bool:
             logger.warning('ThePornDB provider would require a porndb_token in production')
         elif config.metadata_provider.lower() == 'stashdb' and (not config.stashdb_endpoint or config.stashdb_endpoint.strip() == ''):
             logger.warning('StashDB provider would require stashdb_endpoint in production')
-    
+
     return success
 
 

--- a/namer/disambiguation.py
+++ b/namer/disambiguation.py
@@ -6,9 +6,9 @@ from typing import Iterable, List, Tuple
 
 
 class Decision(str, Enum):
-    ACCEPT = "accept"
-    AMBIGUOUS = "ambiguous"
-    REJECT = "reject"
+    ACCEPT = 'accept'
+    AMBIGUOUS = 'ambiguous'
+    REJECT = 'reject'
 
 
 @dataclass(frozen=True)
@@ -20,6 +20,7 @@ class Candidate:
     - guid: unique identifier of the candidate (e.g., scene ID)
     - phash_distance: Hamming distance from the query perceptual hash (lower is better)
     """
+
     guid: str
     phash_distance: int
 
@@ -37,7 +38,7 @@ def _majority_fraction(candidates: Iterable[Candidate]) -> Tuple[str, float]:
         counts[c.guid] = counts.get(c.guid, 0) + 1
         total += 1
     if total == 0:
-        return "", 0.0
+        return '', 0.0
     top_guid, top_count = max(counts.items(), key=lambda kv: kv[1])
     return top_guid, top_count / total
 
@@ -70,7 +71,7 @@ def decide(
     Returns (guid, Decision). For non-ACCEPT cases, guid will be "".
     """
     if not candidates:
-        return "", Decision.REJECT
+        return '', Decision.REJECT
 
     ordered = sorted(candidates, key=lambda c: c.phash_distance)
     best = ordered[0]
@@ -85,9 +86,9 @@ def decide(
         top_guid, frac = _majority_fraction(ordered)
         if top_guid == best.guid and frac >= majority_accept_fraction:
             return best.guid, Decision.ACCEPT
-        return "", Decision.AMBIGUOUS
+        return '', Decision.AMBIGUOUS
 
     if ambiguous_min <= best.phash_distance <= ambiguous_max:
-        return "", Decision.AMBIGUOUS
+        return '', Decision.AMBIGUOUS
 
-    return "", Decision.REJECT
+    return '', Decision.REJECT

--- a/namer/ffmpeg_enhanced.py
+++ b/namer/ffmpeg_enhanced.py
@@ -54,11 +54,11 @@ from namer.videophash.videophashstash import StashVideoPerceptualHash
 
 class QSVCodecMapper:
     """Maps video codecs to their corresponding QSV decoders."""
-    
+
     # Mapping of codec names to QSV decoder names
     CODEC_TO_QSV_DECODER = {
         'h264': 'h264_qsv',
-        'hevc': 'hevc_qsv', 
+        'hevc': 'hevc_qsv',
         'h265': 'hevc_qsv',  # alias for hevc
         'av1': 'av1_qsv',
         'vp9': 'vp9_qsv',
@@ -68,14 +68,14 @@ class QSVCodecMapper:
         'vc1': 'vc1_qsv',
         'mjpeg': 'mjpeg_qsv',
     }
-    
+
     @classmethod
     def get_qsv_decoder(cls, codec_name: str) -> Optional[str]:
         """Get the appropriate QSV decoder for a given codec."""
         if not codec_name:
             return None
         return cls.CODEC_TO_QSV_DECODER.get(codec_name.lower())
-    
+
     @classmethod
     def is_qsv_supported(cls, codec_name: str) -> bool:
         """Check if a codec has QSV support."""
@@ -172,11 +172,12 @@ class FFProbeResults:
 class FFMpeg:
     """
     FFmpeg interface with hardware acceleration support.
-    
+
     ⚠️  PRODUCTION VERSION - DUAL-FILE MAINTENANCE WARNING:
     This is the CONTAINER PRODUCTION version! Any changes here should also
     be applied to the base ffmpeg.py for local development consistency.
     """
+
     __local_dir: Optional[Path] = None
     __ffmpeg_cmd: str = 'ffmpeg'
     __ffprobe_cmd: str = 'ffprobe'
@@ -275,23 +276,23 @@ class FFMpeg:
             probe_result = self.ffprobe(file)
             if not probe_result:
                 return None
-                
+
             video_stream = probe_result.get_default_video_stream()
             if not video_stream:
                 return None
-                
+
             codec_name = video_stream.codec_name
             qsv_decoder = QSVCodecMapper.get_qsv_decoder(codec_name)
-            
+
             if qsv_decoder:
-                logger.debug(f"Auto-detected QSV decoder for {file}: {codec_name} -> {qsv_decoder}")
+                logger.debug(f'Auto-detected QSV decoder for {file}: {codec_name} -> {qsv_decoder}')
                 return qsv_decoder
             else:
-                logger.debug(f"No QSV decoder available for codec: {codec_name}")
+                logger.debug(f'No QSV decoder available for codec: {codec_name}')
                 return None
-                
+
         except Exception as ex:
-            logger.debug(f"Failed to auto-detect QSV decoder for {file}: {ex}")
+            logger.debug(f'Failed to auto-detect QSV decoder for {file}: {ex}')
             return None
 
     def _get_gpu_settings_from_env(self) -> Tuple[Optional[str], Optional[str]]:
@@ -300,13 +301,13 @@ class FFMpeg:
         Returns (device_path, backend) tuple.
         """
         device = os.environ.get('NAMER_GPU_DEVICE')
-        backend = os.environ.get('NAMER_GPU_BACKEND') 
-        
+        backend = os.environ.get('NAMER_GPU_BACKEND')
+
         if device and backend:
-            logger.debug(f"Using GPU settings from environment: device={device}, backend={backend}")
+            logger.debug(f'Using GPU settings from environment: device={device}, backend={backend}')
             return device, backend
         else:
-            logger.debug("No GPU settings found in environment variables")
+            logger.debug('No GPU settings found in environment variables')
             return None, None
 
     def get_audio_stream_for_lang(self, file: Path, language: str) -> int:
@@ -402,9 +403,7 @@ class FFMpeg:
             mp4_file.unlink()
         return success
 
-    def extract_screenshot(self, file: Path, screenshot_time: float, screenshot_width: int = -1, use_gpu: bool = False,
-                           hwaccel_backend: Optional[str] = None, hwaccel_device: Optional[str] = None,
-                           hwaccel_decoder: Optional[str] = None) -> Image.Image:
+    def extract_screenshot(self, file: Path, screenshot_time: float, screenshot_width: int = -1, use_gpu: bool = False, hwaccel_backend: Optional[str] = None, hwaccel_device: Optional[str] = None, hwaccel_decoder: Optional[str] = None) -> Image.Image:
         """
         Extract a single frame as an image with enhanced QSV support and automatic decoder selection.
 
@@ -415,9 +414,10 @@ class FFMpeg:
 
         Enhanced robust fallback order:
         1. If QSV is available: auto-detect decoder based on codec, try QSV decode+scale
-        2. If backend == 'vaapi': try VAAPI (hwupload -> scale_vaapi -> hwdownload -> format)  
+        2. If backend == 'vaapi': try VAAPI (hwupload -> scale_vaapi -> hwdownload -> format)
         3. Software fallback with multiple retry strategies
         """
+
         def _run_pipeline(stream_builder, global_args_list):
             return (
                 stream_builder
@@ -429,15 +429,15 @@ class FFMpeg:
 
         # Normalize inputs and get environment-based GPU settings
         env_device, env_backend = self._get_gpu_settings_from_env()
-        
+
         # Use environment settings if available, otherwise fall back to parameters
         final_backend = env_backend or hwaccel_backend
         final_device = env_device or hwaccel_device
-        
+
         # Override use_gpu based on environment
         if env_backend:
             use_gpu = True
-            
+
         backend = (final_backend or '').lower() if final_backend else None
         width = screenshot_width if screenshot_width and screenshot_width > 0 else -1
 
@@ -447,12 +447,12 @@ class FFMpeg:
                 # Auto-detect the best decoder for this video's codec
                 auto_decoder = self._auto_detect_qsv_decoder(file) if not hwaccel_decoder else None
                 selected_decoder = hwaccel_decoder or auto_decoder
-                
+
                 if selected_decoder:
-                    logger.debug(f"Using QSV decoder: {selected_decoder} for {file}")
+                    logger.debug(f'Using QSV decoder: {selected_decoder} for {file}')
                 else:
-                    logger.debug(f"No QSV decoder specified or auto-detected for {file}, trying generic QSV")
-                
+                    logger.debug(f'No QSV decoder specified or auto-detected for {file}, trying generic QSV')
+
                 input_args = {'hwaccel': 'qsv'}
                 if selected_decoder:
                     input_args['vcodec'] = selected_decoder
@@ -468,32 +468,20 @@ class FFMpeg:
                 if width and width > 0:
                     # QSV decode -> QSV scale -> download -> format conversion optimized for AV1/high-bit-depth
                     filtered = (
-                        stream
-                        .filter('scale_qsv', w=width, h=-1)
+                        stream.filter('scale_qsv', w=width, h=-1)
                         .filter('hwdownload')
                         .filter('format', 'nv12')  # Use NV12 as intermediate - better for QSV output
                         .filter('format', 'rgb24')  # Convert to RGB24 for reliable APNG encoding
                     )
-                    out, _ = (
-                        filtered
-                        .output('pipe:', vframes=1, format='apng')
-                        .global_args(*global_args)
-                        .run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
-                    )
+                    out, _ = filtered.output('pipe:', vframes=1, format='apng').global_args(*global_args).run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
                 else:
                     # QSV decode -> download -> format conversion optimized for AV1/high-bit-depth
                     filtered = (
-                        stream
-                        .filter('hwdownload')
+                        stream.filter('hwdownload')
                         .filter('format', 'nv12')  # Use NV12 as intermediate - native QSV output format
                         .filter('format', 'rgb24')  # Convert to RGB24 for reliable APNG encoding
                     )
-                    out, _ = (
-                        filtered
-                        .output('pipe:', vframes=1, format='apng')
-                        .global_args(*global_args)
-                        .run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
-                    )
+                    out, _ = filtered.output('pipe:', vframes=1, format='apng').global_args(*global_args).run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
 
                 logger.debug(f"QSV decode successful for {file} using decoder: {selected_decoder or 'generic'}")
                 return Image.open(BytesIO(out))
@@ -513,57 +501,44 @@ class FFMpeg:
                     # Try to include stderr if present on ffmpeg Error
                     try:
                         import ffmpeg as _ff
+
                         if isinstance(ex, _ff._run.Error) and getattr(ex, 'stderr', None):
                             err_msg = ex.stderr.decode('utf-8', errors='ignore')
                             err_msg_short = err_msg.strip().split('\n')[-5:]
-                            logger.warning('QSV pipeline (device={}, decoder={}) failed for {}. Falling back to VAAPI/software. Details: {}',
-                                           key_device, key_decoder, file, '\n'.join(err_msg_short))
+                            logger.warning('QSV pipeline (device={}, decoder={}) failed for {}. Falling back to VAAPI/software. Details: {}', key_device, key_decoder, file, '\n'.join(err_msg_short))
                         else:
-                            logger.warning('QSV pipeline (device={}, decoder={}) failed for {}, falling back to VAAPI/software: {}',
-                                           key_device, key_decoder, file, ex)
+                            logger.warning('QSV pipeline (device={}, decoder={}) failed for {}, falling back to VAAPI/software: {}', key_device, key_decoder, file, ex)
                     except Exception:
-                        logger.warning('QSV pipeline (device={}, decoder={}) failed for {}, falling back to VAAPI/software: {}',
-                                       key_device, key_decoder, file, ex)
+                        logger.warning('QSV pipeline (device={}, decoder={}) failed for {}, falling back to VAAPI/software: {}', key_device, key_decoder, file, ex)
                 else:
-                    logger.debug('QSV pipeline (device={}, decoder={}) failed for {} (repeat), falling back to VAAPI/software: {}',
-                                 key_device, key_decoder, file, ex)
-                
+                    logger.debug('QSV pipeline (device={}, decoder={}) failed for {} (repeat), falling back to VAAPI/software: {}', key_device, key_decoder, file, ex)
+
                 # ⚠️  Special handling for AV1 QSV decoder failures - try without specific decoder
                 if selected_decoder == 'av1_qsv' and not hwaccel_decoder:
                     try:
-                        logger.debug(f"Retrying QSV without av1_qsv decoder for {file}")
+                        logger.debug(f'Retrying QSV without av1_qsv decoder for {file}')
                         input_args_generic = {'hwaccel': 'qsv'}
                         global_args = []
                         if final_device:
                             global_args.extend(['-qsv_device', final_device])
-                        
+
                         stream_generic = ffmpeg.input(file, ss=screenshot_time, **input_args_generic)
-                        
+
                         if width and width > 0:
                             filtered = (
-                                stream_generic
-                                .filter('scale_qsv', w=width, h=-1)
-                                .filter('hwdownload')
-                                .filter('format', 'rgb24')  # Consistent format
+                                stream_generic.filter('scale_qsv', w=width, h=-1).filter('hwdownload').filter('format', 'rgb24')  # Consistent format
                             )
                         else:
                             filtered = (
-                                stream_generic
-                                .filter('hwdownload')
-                                .filter('format', 'rgb24')  # Consistent format
+                                stream_generic.filter('hwdownload').filter('format', 'rgb24')  # Consistent format
                             )
-                        
-                        out_generic, _ = (
-                            filtered
-                            .output('pipe:', vframes=1, format='apng')
-                            .global_args(*global_args)
-                            .run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
-                        )
-                        
-                        logger.debug(f"QSV decode successful for {file} using generic QSV (av1_qsv fallback)")
+
+                        out_generic, _ = filtered.output('pipe:', vframes=1, format='apng').global_args(*global_args).run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
+
+                        logger.debug(f'QSV decode successful for {file} using generic QSV (av1_qsv fallback)')
                         return Image.open(BytesIO(out_generic))
                     except Exception as ex_generic:
-                        logger.debug(f"Generic QSV fallback also failed for {file}: {ex_generic}")
+                        logger.debug(f'Generic QSV fallback also failed for {file}: {ex_generic}')
 
         # 2) Attempt VAAPI fallback (if QSV failed or if VAAPI was explicitly requested)
         if use_gpu and (backend == 'vaapi' or backend == 'qsv'):  # Also try VAAPI if QSV failed
@@ -579,12 +554,7 @@ class FFMpeg:
                     if width and width > 0:
                         filt_local = filt_local.filter('scale_vaapi', width, -2)
                     filt_local = filt_local.filter('hwdownload').filter('format', 'rgb24')  # Use rgb24 for consistency with QSV/SW
-                    out_bytes, _err = (
-                        filt_local
-                        .output('pipe:', vframes=1, format='image2', vcodec='png', update=1)
-                        .global_args(*ga)
-                        .run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
-                    )
+                    out_bytes, _err = filt_local.output('pipe:', vframes=1, format='image2', vcodec='png', update=1).global_args(*ga).run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
                     return out_bytes
 
                 # Build candidate list: env device -> configured -> all render nodes
@@ -613,7 +583,7 @@ class FFMpeg:
                             if dev:
                                 with FFMpeg.__vaapi_lock:
                                     FFMpeg.__vaapi_device_cached = dev
-                            logger.debug(f"VAAPI decode successful for {file} using device: {dev}")
+                            logger.debug(f'VAAPI decode successful for {file} using device: {dev}')
                             return Image.open(BytesIO(out))
                     except Exception as ex2:
                         last_ex = ex2
@@ -624,7 +594,7 @@ class FFMpeg:
 
             except Exception as ex:
                 key_backend = 'vaapi'
-                key_device = final_device or 'none'  
+                key_device = final_device or 'none'
                 key = (key_backend, key_device, str(file))
                 first_time = False
                 with FFMpeg.__gpu_warned_lock:
@@ -643,11 +613,10 @@ class FFMpeg:
             stream_sw = ffmpeg.input(file, ss=screenshot_time)
             if width and width > 0:
                 stream_sw = stream_sw.filter('scale', width, -2)
-            
+
             # Apply consistent color format processing to match hardware paths
             stream_sw = (
-                stream_sw
-                .filter('format', 'rgb24')  # Use RGB24 for consistent APNG encoding (matches QSV path)
+                stream_sw.filter('format', 'rgb24')  # Use RGB24 for consistent APNG encoding (matches QSV path)
             )
             out, _err = _run_pipeline(stream_sw, [])
             try:
@@ -658,6 +627,7 @@ class FFMpeg:
         except Exception as ex:
             try:
                 import ffmpeg as _ff
+
                 if isinstance(ex, _ff._run.Error) and getattr(ex, 'stderr', None):
                     err_msg = ex.stderr.decode('utf-8', errors='ignore')
                     err_tail = '\n'.join(err_msg.strip().split('\n')[-5:])
@@ -673,11 +643,7 @@ class FFMpeg:
                     stream_sw2 = stream_sw2.filter('scale', width, -2)
                 # Apply consistent format processing
                 stream_sw2 = stream_sw2.filter('format', 'rgb24')
-                out2, _err2 = (
-                    stream_sw2
-                    .output('pipe:', vframes=1, format='image2', vcodec='png', update=1)
-                    .run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
-                )
+                out2, _err2 = stream_sw2.output('pipe:', vframes=1, format='image2', vcodec='png', update=1).run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
                 try:
                     return Image.open(BytesIO(out2))
                 except Exception as pil_ex2:
@@ -686,6 +652,7 @@ class FFMpeg:
             except Exception as ex2:
                 try:
                     import ffmpeg as _ff
+
                     if isinstance(ex2, _ff._run.Error) and getattr(ex2, 'stderr', None):
                         err_msg2 = ex2.stderr.decode('utf-8', errors='ignore')
                         err_tail2 = '\n'.join(err_msg2.strip().split('\n')[-5:])
@@ -701,11 +668,7 @@ class FFMpeg:
                     stream_sw3 = stream_sw3.filter('scale', width, -2)
                 # Apply consistent format processing
                 stream_sw3 = stream_sw3.filter('format', 'rgb24')
-                out3, _err3 = (
-                    stream_sw3
-                    .output('pipe:', vframes=1, ss=screenshot_time, format='apng')
-                    .run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
-                )
+                out3, _err3 = stream_sw3.output('pipe:', vframes=1, ss=screenshot_time, format='apng').run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
                 return Image.open(BytesIO(out3))
             except Exception:
                 try:
@@ -714,11 +677,7 @@ class FFMpeg:
                         stream_sw4 = stream_sw4.filter('scale', width, -2)
                     # Apply consistent format processing
                     stream_sw4 = stream_sw4.filter('format', 'rgb24')
-                    out4, _err4 = (
-                        stream_sw4
-                        .output('pipe:', vframes=1, ss=screenshot_time, format='image2', vcodec='png')
-                        .run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
-                    )
+                    out4, _err4 = stream_sw4.output('pipe:', vframes=1, ss=screenshot_time, format='image2', vcodec='png').run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
                     return Image.open(BytesIO(out4))
                 except Exception:
                     pass
@@ -731,11 +690,7 @@ class FFMpeg:
                         stream_sw5 = stream_sw5.filter('scale', width, -2)
                     # Apply consistent format processing
                     stream_sw5 = stream_sw5.filter('format', 'rgb24')
-                    out5, _err5 = (
-                        stream_sw5
-                        .output('pipe:', vframes=1, ss=t2, format='image2', vcodec='png')
-                        .run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
-                    )
+                    out5, _err5 = stream_sw5.output('pipe:', vframes=1, ss=t2, format='image2', vcodec='png').run(quiet=True, capture_stdout=True, capture_stderr=True, cmd=self.__ffmpeg_cmd)
                     return Image.open(BytesIO(out5))
                 except Exception:
                     continue

--- a/namer/metadata_providers/__init__.py
+++ b/namer/metadata_providers/__init__.py
@@ -10,11 +10,4 @@ from .factory import ProviderFactory, get_metadata_provider
 from .theporndb_provider import ThePornDBProvider
 from .stashdb_provider import StashDBProvider
 
-__all__ = [
-    'MetadataProvider', 
-    'BaseMetadataProvider',
-    'ProviderFactory', 
-    'get_metadata_provider',
-    'ThePornDBProvider',
-    'StashDBProvider'
-]
+__all__ = ['MetadataProvider', 'BaseMetadataProvider', 'ProviderFactory', 'get_metadata_provider', 'ThePornDBProvider', 'StashDBProvider']

--- a/namer/metadata_providers/factory.py
+++ b/namer/metadata_providers/factory.py
@@ -16,55 +16,52 @@ class ProviderFactory:
     """
     Factory for creating metadata provider instances based on configuration.
     """
-    
+
     # Registry of available providers
     _providers: Dict[str, Type[MetadataProvider]] = {
         'theporndb': ThePornDBProvider,
         'stashdb': StashDBProvider,
     }
-    
+
     @classmethod
     def create_provider(cls, config: NamerConfig) -> MetadataProvider:
         """
         Create a metadata provider instance based on the configuration.
-        
+
         Args:
             config: Namer configuration containing provider selection
-            
+
         Returns:
             MetadataProvider instance
-            
+
         Raises:
             ValueError: If the specified provider is not supported
         """
         provider_name = config.metadata_provider.lower()
-        
+
         if provider_name not in cls._providers:
             supported_providers = ', '.join(cls._providers.keys())
-            raise ValueError(
-                f"Unsupported metadata provider: '{provider_name}'. "
-                f"Supported providers: {supported_providers}"
-            )
-        
+            raise ValueError(f"Unsupported metadata provider: '{provider_name}'. " f'Supported providers: {supported_providers}')
+
         provider_class = cls._providers[provider_name]
         return provider_class()
-    
+
     @classmethod
     def register_provider(cls, name: str, provider_class: Type[MetadataProvider]) -> None:
         """
         Register a new metadata provider.
-        
+
         Args:
             name: Provider name (used in configuration)
             provider_class: Provider class that implements MetadataProvider
         """
         cls._providers[name.lower()] = provider_class
-    
+
     @classmethod
     def get_available_providers(cls) -> list[str]:
         """
         Get list of available provider names.
-        
+
         Returns:
             List of provider names
         """
@@ -74,10 +71,10 @@ class ProviderFactory:
 def get_metadata_provider(config: NamerConfig) -> MetadataProvider:
     """
     Convenience function to get a metadata provider instance.
-    
+
     Args:
         config: Namer configuration
-        
+
     Returns:
         MetadataProvider instance
     """

--- a/namer/metadata_providers/provider.py
+++ b/namer/metadata_providers/provider.py
@@ -18,75 +18,75 @@ from namer.videophash import PerceptualHash
 class MetadataProvider(Protocol):
     """
     Protocol defining the interface for metadata providers.
-    
+
     All metadata providers must implement these methods to provide
     consistent functionality across different provider implementations.
     """
-    
+
     def match(self, file_name_parts: Optional[FileInfo], config: NamerConfig, phash: Optional[PerceptualHash] = None) -> ComparisonResults:
         """
         Search for metadata matches based on file name parts and/or perceptual hash.
-        
+
         Args:
             file_name_parts: Parsed file name components
             config: Namer configuration
             phash: Optional perceptual hash for matching
-            
+
         Returns:
             ComparisonResults containing sorted list of potential matches
         """
         ...
-    
+
     def get_complete_info(self, file_name_parts: Optional[FileInfo], uuid: str, config: NamerConfig) -> Optional[LookedUpFileInfo]:
         """
         Get complete metadata information for a specific item by UUID.
-        
+
         Args:
-            file_name_parts: Parsed file name components  
+            file_name_parts: Parsed file name components
             uuid: Unique identifier for the metadata item
             config: Namer configuration
-            
+
         Returns:
             Complete LookedUpFileInfo or None if not found
         """
         ...
-    
+
     def search(self, query: str, scene_type: SceneType, config: NamerConfig, page: int = 1) -> List[LookedUpFileInfo]:
         """
         Search for metadata by text query.
-        
+
         Args:
             query: Search query string
-            scene_type: Type of content to search for (SCENE, MOVIE, JAV)  
+            scene_type: Type of content to search for (SCENE, MOVIE, JAV)
             config: Namer configuration
             page: Page number for paginated results
-            
+
         Returns:
             List of LookedUpFileInfo results
         """
         ...
-    
+
     def download_file(self, url: str, file: Path, config: NamerConfig) -> bool:
         """
         Download a file (image, trailer) from the provider.
-        
+
         Args:
             url: URL to download
             file: Local file path to save to
             config: Namer configuration
-            
+
         Returns:
             True if successful, False otherwise
         """
         ...
-    
+
     def get_user_info(self, config: NamerConfig) -> Optional[dict]:
         """
         Get user information from the provider API.
-        
+
         Args:
             config: Namer configuration
-            
+
         Returns:
             User info dict or None if not available
         """
@@ -96,39 +96,40 @@ class MetadataProvider(Protocol):
 class BaseMetadataProvider(ABC):
     """
     Abstract base class providing common functionality for metadata providers.
-    
+
     Providers can extend this class to inherit common functionality and
     only need to implement the abstract methods specific to their API.
     """
-    
+
     @abstractmethod
     def match(self, file_name_parts: Optional[FileInfo], config: NamerConfig, phash: Optional[PerceptualHash] = None) -> ComparisonResults:
         """Search for metadata matches."""
         pass
-    
-    @abstractmethod  
+
+    @abstractmethod
     def get_complete_info(self, file_name_parts: Optional[FileInfo], uuid: str, config: NamerConfig) -> Optional[LookedUpFileInfo]:
         """Get complete metadata information for a specific item."""
         pass
-    
+
     @abstractmethod
     def search(self, query: str, scene_type: SceneType, config: NamerConfig, page: int = 1) -> List[LookedUpFileInfo]:
-        """Search for metadata by text query.""" 
+        """Search for metadata by text query."""
         pass
-    
+
     def download_file(self, url: str, file: Path, config: NamerConfig) -> bool:
         """
         Default file download implementation.
-        
+
         Providers can override this for custom download logic.
         """
         from namer.metadataapi import download_file as default_download
+
         return default_download(url, file, config)
-    
+
     def get_user_info(self, config: NamerConfig) -> Optional[dict]:
         """
         Default user info implementation.
-        
+
         Returns None by default; providers can override for custom user info.
         """
         return None

--- a/namer/metadata_providers/stashdb_provider.py
+++ b/namer/metadata_providers/stashdb_provider.py
@@ -24,25 +24,25 @@ from namer.videophash import PerceptualHash
 class StashDBProvider(BaseMetadataProvider):
     """
     StashDB GraphQL metadata provider.
-    
+
     Interfaces with StashDB's GraphQL endpoint to provide metadata
     and maps results to namer's existing data structures.
     """
-    
+
     def __init__(self):
         """Initialize the StashDB provider."""
         pass
-    
+
     def match(self, file_name_parts: Optional[FileInfo], config: NamerConfig, phash: Optional[PerceptualHash] = None) -> ComparisonResults:
         """
         Search for metadata matches based on file name parts and/or perceptual hash.
         """
         results: List[ComparisonResult] = []
-        
+
         # For now, implement a basic search using scene title
         if file_name_parts and file_name_parts.name:
             scene_results = self.search(file_name_parts.name, SceneType.SCENE, config)
-            
+
             # Convert to ComparisonResult objects
             for scene_info in scene_results:
                 # Create a basic comparison result - this would need more sophisticated
@@ -58,7 +58,7 @@ class StashDBProvider(BaseMetadataProvider):
                     phash_duration=None,
                 )
                 results.append(comparison_result)
-        
+
         # Handle phash-based searches
         if phash:
             try:
@@ -66,43 +66,43 @@ class StashDBProvider(BaseMetadataProvider):
                 if phash_results:
                     # Get unique scene IDs from phash results
                     unique_scene_ids = set(scene_info.guid for scene_info in phash_results if scene_info.guid)
-                    
+
                     if len(unique_scene_ids) == 1:
                         # Single unique scene - treat as super match and return only one result
-                        logger.info(f"Phash match found single unique scene with {len(phash_results)} submissions - returning confident match")
+                        logger.info(f'Phash match found single unique scene with {len(phash_results)} submissions - returning confident match')
                         results.clear()  # Clear any name-based search results
                         # Only add the first result to avoid conflict logic in get_match()
                         scene_info = phash_results[0]
                         comparison_result = ComparisonResult(
                             name=scene_info.name or '',
                             name_match=100.0,  # Force high name match for unique phash
-                            date_match=True,    # Force date match for unique phash
-                            site_match=True,    # Force site match for unique phash
+                            date_match=True,  # Force date match for unique phash
+                            site_match=True,  # Force site match for unique phash
                             name_parts=file_name_parts,
                             looked_up=scene_info,
-                            phash_distance=0,   # Perfect phash match
+                            phash_distance=0,  # Perfect phash match
                             phash_duration=True,
                         )
                         results.append(comparison_result)
                     elif len(unique_scene_ids) > 1:
                         # Multiple unique scenes - log failure and reject
-                        logger.error(f"Multiple scene IDs exist for this phash: {len(unique_scene_ids)} unique scenes found ({unique_scene_ids})")
+                        logger.error(f'Multiple scene IDs exist for this phash: {len(unique_scene_ids)} unique scenes found ({unique_scene_ids})')
                         # Don't add any phash results to avoid ambiguity
                     # If no unique scene IDs (shouldn't happen), fall through to name search
             except Exception as e:
-                logger.debug(f"Phash search failed: {e}")
-        
+                logger.debug(f'Phash search failed: {e}')
+
         # Sort results by quality
         results = sorted(results, key=self._calculate_match_weight, reverse=True)
-        
+
         return ComparisonResults(results, file_name_parts)
-    
+
     def get_complete_info(self, file_name_parts: Optional[FileInfo], uuid: str, config: NamerConfig) -> Optional[LookedUpFileInfo]:
         """
         Get complete metadata information for a specific item by UUID.
         """
         query = {
-            'query': '''
+            'query': """
                 query FindScene($id: ID!) {
                     findScene(id: $id) {
                         id
@@ -142,18 +142,18 @@ class StashDBProvider(BaseMetadataProvider):
                         }
                     }
                 }
-            ''',
+            """,
             'variables': {
                 'id': uuid.split('/')[-1]  # Extract ID from UUID
-            }
+            },
         }
-        
+
         response = self._execute_graphql_query(query, config)
         if response and 'data' in response and response['data']['findScene']:
             return self._map_stashdb_scene_to_fileinfo(response['data']['findScene'], config)
-        
+
         return None
-    
+
     def search(self, query: str, scene_type: SceneType, config: NamerConfig, page: int = 1) -> List[LookedUpFileInfo]:
         """
         Search for metadata by text query.
@@ -161,7 +161,7 @@ class StashDBProvider(BaseMetadataProvider):
         # StashDB primarily deals with scenes, so we'll search scenes regardless of scene_type
         # Based on error messages, StashDB expects 'term' parameter and returns direct array
         graphql_query = {
-            'query': '''
+            'query': """
                 query SearchScenes($term: String!) {
                     searchScene(term: $term) {
                         id
@@ -201,15 +201,13 @@ class StashDBProvider(BaseMetadataProvider):
                         }
                     }
                 }
-            ''',
-            'variables': {
-                'term': query
-            }
+            """,
+            'variables': {'term': query},
         }
-        
+
         response = self._execute_graphql_query(graphql_query, config)
         results = []
-        
+
         if response and 'data' in response and response['data'] and 'searchScene' in response['data']:
             # StashDB returns scenes directly, not wrapped in a 'scenes' object
             scenes = response['data']['searchScene']
@@ -218,16 +216,16 @@ class StashDBProvider(BaseMetadataProvider):
                     file_info = self._map_stashdb_scene_to_fileinfo(scene, config)
                     if file_info:
                         results.append(file_info)
-        
+
         return results
-    
+
     def download_file(self, url: str, file: Path, config: NamerConfig) -> bool:
         """
         Download a file (image, trailer) from StashDB.
         """
         # Use the default implementation from base class
         return super().download_file(url, file, config)
-    
+
     def get_user_info(self, config: NamerConfig) -> Optional[dict]:
         """
         Get user information from StashDB API.
@@ -235,7 +233,7 @@ class StashDBProvider(BaseMetadataProvider):
         We return a placeholder to allow watchdog to start even if this fails.
         """
         query = {
-            'query': '''
+            'query': """
                 query Me {
                     me {
                         id
@@ -243,26 +241,22 @@ class StashDBProvider(BaseMetadataProvider):
                         roles
                     }
                 }
-            ''',
-            'variables': {}
+            """,
+            'variables': {},
         }
-        
+
         response = self._execute_graphql_query(query, config)
         if response and 'data' in response and response['data'] and response['data']['me']:
             return response['data']['me']
-        
+
         # If me query fails but we have a token, return placeholder user info
         # to allow watchdog to continue running. Search functionality will still work.
         if config.stashdb_token:
             logger.warning("StashDB 'me' query failed, but token is configured. Continuing with placeholder user info.")
-            return {
-                'id': 'unknown',
-                'name': 'StashDB User (me query unavailable)',
-                'roles': []
-            }
-        
+            return {'id': 'unknown', 'name': 'StashDB User (me query unavailable)', 'roles': []}
+
         return None
-    
+
     def _execute_graphql_query(self, query: Dict[str, Any], config: NamerConfig) -> Optional[Dict[str, Any]]:
         """
         Execute a GraphQL query against StashDB.
@@ -272,38 +266,38 @@ class StashDBProvider(BaseMetadataProvider):
             'Accept': 'application/json',
             'User-Agent': 'namer-1',
         }
-        
+
         if config.stashdb_token:
             # StashDB uses APIKey header for authentication (not Bearer token)
             headers['APIKey'] = config.stashdb_token
-        
+
         data = orjson.dumps(query)
         # Endpoint resolution order: env > config override > built-in default
         endpoint = os.environ.get('STASHDB_ENDPOINT') or (config.stashdb_endpoint or '').strip() or 'https://stashdb.org/graphql'
         http = Http.request(RequestType.POST, endpoint, cache_session=config.cache_session, headers=headers, data=data)
-        
+
         if http.ok:
             try:
                 response_data = orjson.loads(http.content)
-                
+
                 # Check for GraphQL errors
                 if 'errors' in response_data:
                     logger.error(f'StashDB GraphQL errors: {response_data["errors"]}')
-                
+
                 return response_data
             except JSONDecodeError as e:
                 logger.error(f'Failed to parse StashDB response: {e}')
         else:
             logger.error(f'StashDB API error: {http.status_code} - {http.text}')
-        
+
         return None
-    
+
     def _map_stashdb_scene_to_fileinfo(self, scene: Dict[str, Any], config: NamerConfig) -> Optional[LookedUpFileInfo]:
         """
         Map StashDB scene data to LookedUpFileInfo.
         """
         file_info = LookedUpFileInfo()
-        
+
         # Basic scene information
         file_info.type = SceneType.SCENE
         file_info.uuid = f"scenes/{scene['id']}"
@@ -311,24 +305,24 @@ class StashDBProvider(BaseMetadataProvider):
         file_info.name = scene.get('title', '')
         file_info.description = scene.get('details', '')
         file_info.date = scene.get('date', '')
-        
+
         # Handle URLs array (StashDB uses 'urls' not 'url')
         if scene.get('urls') and len(scene['urls']) > 0:
             file_info.source_url = scene['urls'][0].get('url', '')
-        
+
         file_info.duration = scene.get('duration')
-        
+
         # Studio information
         if scene.get('studio'):
             studio = scene['studio']
             file_info.site = studio.get('name', '')
             if studio.get('parent'):
                 file_info.parent = studio['parent'].get('name', '')
-        
+
         # Images
         if scene.get('images') and len(scene['images']) > 0:
             file_info.poster_url = scene['images'][0].get('url', '')
-        
+
         # Performers
         if scene.get('performers'):
             for perf_data in scene['performers']:
@@ -336,42 +330,38 @@ class StashDBProvider(BaseMetadataProvider):
                 if performer_info.get('name'):
                     performer = Performer(performer_info['name'])
                     performer.role = performer_info.get('gender', '')
-                    
+
                     # Handle aliases
                     if performer_info.get('aliases'):
                         performer.alias = ', '.join(performer_info['aliases'])
-                    
+
                     # Handle images
                     if performer_info.get('images') and len(performer_info['images']) > 0:
                         performer.image = performer_info['images'][0].get('url', '')
-                    
+
                     file_info.performers.append(performer)
-        
+
         # Tags
         if scene.get('tags'):
             file_info.tags = [tag['name'] for tag in scene['tags'] if tag.get('name')]
-        
+
         # Hashes/Fingerprints
         if scene.get('fingerprints'):
             for fingerprint in scene['fingerprints']:
                 hash_type = fingerprint.get('algorithm', '').upper()
                 if hash_type == 'PHASH':
-                    scene_hash = SceneHash(
-                        scene_hash=fingerprint.get('hash', ''),
-                        hash_type=HashType.PHASH,
-                        duration=fingerprint.get('duration')
-                    )
+                    scene_hash = SceneHash(scene_hash=fingerprint.get('hash', ''), hash_type=HashType.PHASH, duration=fingerprint.get('duration'))
                     file_info.hashes.append(scene_hash)
-        
+
         return file_info
-    
+
     def _search_by_phash(self, phash: PerceptualHash, config: NamerConfig) -> List[LookedUpFileInfo]:
         """
         Search for scenes by perceptual hash.
         """
         # Note: This query structure is a guess - StashDB phash search may need different approach
         query = {
-            'query': '''
+            'query': """
                 query SearchByFingerprint($hash: String!) {
                     findSceneByFingerprint(fingerprint: {hash: $hash, algorithm: PHASH}) {
                         id
@@ -411,15 +401,13 @@ class StashDBProvider(BaseMetadataProvider):
                         }
                     }
                 }
-            ''',
-            'variables': {
-                'hash': str(phash.phash)
-            }
+            """,
+            'variables': {'hash': str(phash.phash)},
         }
-        
+
         response = self._execute_graphql_query(query, config)
         results = []
-        
+
         if response and 'data' in response and response['data'] and 'findSceneByFingerprint' in response['data']:
             scenes = response['data']['findSceneByFingerprint']
             if scenes:
@@ -434,20 +422,21 @@ class StashDBProvider(BaseMetadataProvider):
                     file_info = self._map_stashdb_scene_to_fileinfo(scenes, config)
                     if file_info:
                         results.append(file_info)
-        
+
         return results
-    
+
     def _calculate_name_match(self, query_name: Optional[str], scene_name: Optional[str]) -> float:
         """
         Calculate name match percentage between query and scene names.
         """
         if not query_name or not scene_name:
             return 0.0
-        
+
         # Use rapidfuzz for fuzzy string matching
         import rapidfuzz.fuzz
+
         return rapidfuzz.fuzz.ratio(query_name.lower(), scene_name.lower())
-    
+
     def _compare_dates(self, query_date: Optional[str], scene_date: Optional[str]) -> bool:
         """
         Compare dates between query and scene.
@@ -455,7 +444,7 @@ class StashDBProvider(BaseMetadataProvider):
         if not query_date or not scene_date:
             return False
         return query_date == scene_date
-    
+
     def _compare_sites(self, query_site: Optional[str], scene_site: Optional[str]) -> bool:
         """
         Compare sites between query and scene.
@@ -463,13 +452,13 @@ class StashDBProvider(BaseMetadataProvider):
         if not query_site or not scene_site:
             return False
         return query_site.lower() in scene_site.lower()
-    
+
     def _calculate_match_weight(self, result: ComparisonResult) -> float:
         """
         Calculate match weight for sorting results.
         """
         weight = 0.0
-        
+
         # Phash matches get highest priority
         if result.phash_distance is not None:
             weight += max(1000 - result.phash_distance * 125, 0)
@@ -479,10 +468,10 @@ class StashDBProvider(BaseMetadataProvider):
                 weight += 100
             if result.name_match:
                 weight += result.name_match
-        
+
         # Name matches
         if result.site_match and result.date_match and result.name_match and result.name_match >= 94.9:
             weight += 1000.0
             weight += result.name_match
-        
+
         return weight

--- a/namer/metadata_providers/theporndb_provider.py
+++ b/namer/metadata_providers/theporndb_provider.py
@@ -21,25 +21,25 @@ from namer.videophash import PerceptualHash
 class ThePornDBProvider(BaseMetadataProvider):
     """
     ThePornDB GraphQL metadata provider.
-    
+
     Uses ThePornDB's GraphQL endpoint for metadata lookups and maintains
     compatibility with the existing namer data structures.
     """
-    
+
     def __init__(self):
         """Initialize the ThePornDB provider."""
         pass
-    
+
     @logger.catch
     def _graphql_request(self, query: str, variables: Dict[str, Any], config: NamerConfig) -> Optional[Dict[str, Any]]:
         """
         Send a GraphQL request to ThePornDB.
-        
+
         Args:
             query: GraphQL query string
             variables: Query variables
             config: Namer configuration
-            
+
         Returns:
             GraphQL response data or None if request failed
         """
@@ -49,62 +49,53 @@ class ThePornDBProvider(BaseMetadataProvider):
             'Accept': 'application/json',
             'User-Agent': 'namer-1',
         }
-        
-        payload = {
-            'query': query,
-            'variables': variables
-        }
-        
+
+        payload = {'query': query, 'variables': variables}
+
         data = orjson.dumps(payload)
         # Endpoint resolution order: env > config override > built-in default
         base = os.environ.get('TPDB_ENDPOINT') or (config.override_tpdb_address or '').strip() or 'https://theporndb.net'
         graphql_url = base.rstrip('/') + '/graphql'
-        
+
         try:
-            http = Http.request(
-                RequestType.POST, 
-                graphql_url, 
-                cache_session=config.cache_session, 
-                headers=headers, 
-                data=data
-            )
-            
+            http = Http.request(RequestType.POST, graphql_url, cache_session=config.cache_session, headers=headers, data=data)
+
             if http.ok:
                 response_data = orjson.loads(http.content)
-                
+
                 # Check for GraphQL errors
                 if 'errors' in response_data:
                     for error in response_data['errors']:
                         logger.error(f'GraphQL error: {error.get("message", "Unknown error")}')
                     return None
-                
+
                 return response_data.get('data')
             else:
                 logger.error(f'HTTP error {http.status_code}: {http.text}')
                 return None
-                
+
         except Exception as e:
             logger.error(f'GraphQL request failed: {e}')
             return None
-    
+
     def _graphql_scene_to_fileinfo(self, scene_data: Dict[str, Any], original_query: str, original_response: str, name_parts: Optional[FileInfo]) -> LookedUpFileInfo:
         """
         Convert GraphQL scene data to LookedUpFileInfo object.
-        
+
         Args:
             scene_data: Scene data from GraphQL response
             original_query: Original query for reference
             original_response: Original response for reference
             name_parts: Parsed filename parts
-            
+
         Returns:
             LookedUpFileInfo object
         """
         file_info = LookedUpFileInfo()
-        
+
         # Basic scene information
         file_info.type = SceneType.SCENE  # GraphQL response should indicate type
-        
+
         # Use numeric _id for UUID to maintain legacy compatibility
         numeric_id = scene_data.get('_id', scene_data.get('id', ''))
         file_info.uuid = f'scenes/{numeric_id}'
@@ -118,70 +109,70 @@ class ThePornDBProvider(BaseMetadataProvider):
         else:
             file_info.source_url = scene_data.get('url', '')
         file_info.duration = scene_data.get('duration')
-        
+
         # External ID
         if 'external_id' in scene_data:
             file_info.external_id = scene_data['external_id']
-        
+
         # Image URLs
         if 'poster' in scene_data:
             file_info.poster_url = scene_data['poster']
-        
+
         if 'background' in scene_data and scene_data['background']:
             if isinstance(scene_data['background'], dict):
                 file_info.background_url = scene_data['background'].get('large', '')
             else:
                 file_info.background_url = scene_data['background']
-        
+
         if 'trailer' in scene_data:
             file_info.trailer_url = scene_data['trailer']
-        
+
         # Site information
         if 'site' in scene_data and scene_data['site']:
             site = scene_data['site']
             file_info.site = site.get('name', '')
-            
+
             # Parent and network information
             if 'parent' in site and site['parent']:
                 file_info.parent = site['parent'].get('name', '')
-            
+
             if 'network' in site and site['network']:
                 file_info.network = site['network'].get('name', '')
-        
+
         # Performers
         if 'performers' in scene_data:
             for perf_data in scene_data['performers']:
                 performer_name = perf_data.get('name', '')
                 if not performer_name:
                     continue
-                
+
                 # Use parent name if available
                 if 'parent' in perf_data and perf_data['parent'] and 'name' in perf_data['parent']:
                     performer_name = perf_data['parent']['name']
-                
+
                 performer = Performer(performer_name)
                 performer.alias = perf_data.get('name', '')
-                
+
                 # Gender information
                 if 'parent' in perf_data and perf_data['parent'] and 'extras' in perf_data['parent']:
                     performer.role = perf_data['parent']['extras'].get('gender', '')
                 elif 'extras' in perf_data:
                     performer.role = perf_data['extras'].get('gender', '')
-                
+
                 # Image information
                 if 'parent' in perf_data and perf_data['parent'] and 'image' in perf_data['parent']:
                     performer.image = perf_data['parent']['image']
                 elif 'image' in perf_data:
                     performer.image = perf_data['image']
-                
+
                 file_info.performers.append(performer)
-        
+
         # Tags (deduplicated and sorted to match legacy behavior)
         if 'tags' in scene_data:
             tag_names = [tag['name'] for tag in scene_data['tags'] if 'name' in tag]
             # Deduplicate first, then sort to ensure consistent ordering
             file_info.tags = sorted(list(dict.fromkeys(tag_names)))
-        
+
         # Hashes
         if 'hashes' in scene_data:
             for hash_data in scene_data['hashes']:
@@ -191,24 +182,20 @@ class ThePornDBProvider(BaseMetadataProvider):
                         hash_type = HashType[hash_data['type'].upper()]
                     except KeyError:
                         hash_type = HashType.PHASH
-                
-                scene_hash = SceneHash(
-                    hash_data.get('hash', ''),
-                    hash_type,
-                    hash_data.get('duration')
-                )
+
+                scene_hash = SceneHash(hash_data.get('hash', ''), hash_type, hash_data.get('duration'))
                 file_info.hashes.append(scene_hash)
-        
+
         # Set original query/response for compatibility
         file_info.original_query = original_query
         file_info.original_response = original_response
         file_info.original_parsed_filename = name_parts
-        
+
         # Compatibility fields
         file_info.look_up_site_id = str(numeric_id)
-        
+
         return file_info
-    
+
     def match(self, file_name_parts: Optional[FileInfo], config: NamerConfig, phash: Optional[PerceptualHash] = None) -> ComparisonResults:
         """
         Search for metadata matches based on file name parts and/or perceptual hash using GraphQL.
@@ -233,79 +220,69 @@ class ThePornDBProvider(BaseMetadataProvider):
         if phash:
             hash_results = self._search_by_hash(phash, config)
             for scene_data in hash_results:
-                file_info = self._graphql_scene_to_fileinfo(
-                    scene_data, 
-                    f'hash:{phash.phash}', 
-                    orjson.dumps(scene_data, option=orjson.OPT_INDENT_2).decode('utf-8'),
-                    file_name_parts
-                )
+                file_info = self._graphql_scene_to_fileinfo(scene_data, f'hash:{phash.phash}', orjson.dumps(scene_data, option=orjson.OPT_INDENT_2).decode('utf-8'), file_name_parts)
                 # Mark as found via phash for scoring
                 file_info._found_via_phash = True
                 results.append(file_info)
-        
+
         # Text-based search
         if search_terms:
             query_string = ' '.join(search_terms)
             text_results = self._search_scenes(query_string, SceneType.SCENE, config)
-            
+
             for scene_data in text_results:
                 # Skip if already found via hash
                 scene_id = scene_data.get('id', '')
                 if any(r.guid == scene_id for r in results):
                     continue
-                    
-                file_info = self._graphql_scene_to_fileinfo(
-                    scene_data,
-                    query_string,
-                    orjson.dumps(scene_data, option=orjson.OPT_INDENT_2).decode('utf-8'),
-                    file_name_parts
-                )
+
+                file_info = self._graphql_scene_to_fileinfo(scene_data, query_string, orjson.dumps(scene_data, option=orjson.OPT_INDENT_2).decode('utf-8'), file_name_parts)
                 results.append(file_info)
-        
+
         # Convert to ComparisonResult objects and evaluate matches
         # Import the internal functions we need from metadataapi
         import namer.metadataapi as meta_api
-        
+
         # Use getattr to access private functions without name mangling issues
         evaluate_match_func = getattr(meta_api, '_ThePornDBProvider__evaluate_match', None)
         match_weight_func = getattr(meta_api, '_ThePornDBProvider__match_weight', None)
-        
+
         # If the functions aren't found with class prefix, try module prefix
         if not evaluate_match_func:
             evaluate_match_func = getattr(meta_api, '__evaluate_match', None)
         if not match_weight_func:
             match_weight_func = getattr(meta_api, '__match_weight', None)
-        
+
         comparison_results = []
-        
+
         if evaluate_match_func:
             for file_info in results:
                 comparison_result = evaluate_match_func(file_name_parts, file_info, config, phash)
                 comparison_results.append(comparison_result)
-        
+
         # Sort by match quality
         if match_weight_func:
             comparison_results = sorted(comparison_results, key=match_weight_func, reverse=True)
-        
+
         return ComparisonResults(comparison_results, file_name_parts)
-    
+
     def _search_scenes(self, query: str, scene_type: SceneType, config: NamerConfig, page: int = 1) -> List[Dict[str, Any]]:
         """
         Search for scenes using GraphQL.
         Primary: searchScenes(input: {query, page}) to match test server.
         Fallback: searchScene(term: $term) for newer schema compatibility.
-        
+
         Args:
             query: Search query string
             scene_type: Type of scene to search for
             config: Namer configuration
             page: Page number for pagination
-            
+
         Returns:
             List of scene data from GraphQL response
         """
         # Try current schema: searchScene(term: $term) - this is the correct API
-        search_scene_query = '''
+        search_scene_query = """
             query SearchScene($term: String!) {
                 searchScene(term: $term) {
                     id
@@ -326,31 +303,30 @@ class ThePornDBProvider(BaseMetadataProvider):
                     hashes { hash type duration }
                 }
             }
-        '''
-        variables = { 'term': query }
+        """
+        variables = {'term': query}
         response_data = self._graphql_request(search_scene_query, variables, config)
         if response_data and 'searchScene' in response_data:
             scenes = response_data['searchScene']
             return scenes if isinstance(scenes, list) else []
 
-
         return []
-    
+
     def _search_by_hash(self, phash: PerceptualHash, config: NamerConfig) -> List[Dict[str, Any]]:
         """
         Search for scenes by perceptual hash using GraphQL.
-        
+
         Args:
             phash: Perceptual hash to search for
             config: Namer configuration
-            
+
         Returns:
             List of scene data from GraphQL response
         """
         # The current public TPDB GraphQL schema does not expose a hash search.
         # Disable GraphQL hash search for now; hash-based matching will be covered by name search and/or future schema support.
         return []
-    
+
     def get_complete_info(self, file_name_parts: Optional[FileInfo], uuid: str, config: NamerConfig) -> Optional[LookedUpFileInfo]:
         """
         Get complete metadata information for a specific item by UUID using GraphQL.
@@ -359,8 +335,8 @@ class ThePornDBProvider(BaseMetadataProvider):
         scene_id = uuid
         if '/' in uuid:
             scene_id = uuid.split('/')[-1]
-        
-        scene_query = '''
+
+        scene_query = """
             query GetScene($id: ID!) {
                 findScene(id: $id) {
                     id
@@ -406,76 +382,71 @@ class ThePornDBProvider(BaseMetadataProvider):
                     }
                 }
             }
-        '''
-        
+        """
+
         variables = {'id': scene_id}
-        
+
         response_data = self._graphql_request(scene_query, variables, config)
-        
+
         if response_data and 'findScene' in response_data and response_data['findScene']:
             scene_data = response_data['findScene']
-            
+
             # Mark as collected if needed
             if config.mark_collected and 'isCollected' in scene_data and not scene_data['isCollected']:
                 self._mark_collected(scene_id, config)
-            
-            file_info = self._graphql_scene_to_fileinfo(
-                scene_data,
-                f'findScene:{scene_id}',
-                orjson.dumps(scene_data, option=orjson.OPT_INDENT_2).decode('utf-8'),
-                file_name_parts
-            )
-            
+
+            file_info = self._graphql_scene_to_fileinfo(scene_data, f'findScene:{scene_id}', orjson.dumps(scene_data, option=orjson.OPT_INDENT_2).decode('utf-8'), file_name_parts)
+
             # Set collection status
             file_info.is_collected = scene_data.get('isCollected', False)
-            
+
             return file_info
-        
+
         return None
-    
+
     def _mark_collected(self, scene_id: str, config: NamerConfig) -> bool:
         """
         Mark a scene as collected using GraphQL mutation.
-        
+
         Args:
             scene_id: Scene ID to mark as collected
             config: Namer configuration
-            
+
         Returns:
             True if successful, False otherwise
         """
-        mutation = '''
+        mutation = """
             mutation MarkCollected($sceneId: ID!) {
                 markSceneCollected(sceneId: $sceneId) {
                     success
                     message
                 }
             }
-        '''
-        
+        """
+
         variables = {'sceneId': scene_id}
-        
+
         response_data = self._graphql_request(mutation, variables, config)
-        
+
         if response_data and 'markSceneCollected' in response_data:
             result = response_data['markSceneCollected']
             return result.get('success', False)
-        
+
         return False
-    
+
     def _share_hash(self, scene_id: str, scene_hash: SceneHash, config: NamerConfig) -> bool:
         """
         Share a perceptual hash for a scene using GraphQL mutation.
-        
+
         Args:
             scene_id: Scene ID to share hash for
             scene_hash: Hash data to share
             config: Namer configuration
-            
+
         Returns:
             True if successful, False otherwise
         """
-        mutation = '''
+        mutation = """
             mutation ShareHash($sceneId: ID!, $hash: String!, $hashType: String!, $duration: Int) {
                 shareSceneHash(input: {
                     sceneId: $sceneId,
@@ -487,25 +458,20 @@ class ThePornDBProvider(BaseMetadataProvider):
                     message
                 }
             }
-        '''
-        
-        variables = {
-            'sceneId': scene_id,
-            'hash': scene_hash.hash,
-            'hashType': scene_hash.type.value,
-            'duration': scene_hash.duration
-        }
-        
+        """
+
+        variables = {'sceneId': scene_id, 'hash': scene_hash.hash, 'hashType': scene_hash.type.value, 'duration': scene_hash.duration}
+
         logger.info(f'Sending {scene_hash.type.value}: {scene_hash.hash} with duration {scene_hash.duration}')
-        
+
         response_data = self._graphql_request(mutation, variables, config)
-        
+
         if response_data and 'shareSceneHash' in response_data:
             result = response_data['shareSceneHash']
             return result.get('success', False)
-        
+
         return False
-    
+
     def search(self, query: str, scene_type: SceneType, config: NamerConfig, page: int = 1) -> List[LookedUpFileInfo]:
         """
         Search for metadata by text query using GraphQL.
@@ -521,30 +487,30 @@ class ThePornDBProvider(BaseMetadataProvider):
             )
             file_infos.append(file_info)
         return file_infos
-    
+
     def download_file(self, url: str, file: Path, config: NamerConfig) -> bool:
         """
         Download a file (image, trailer) from ThePornDB.
         """
         from namer import metadataapi
-        
+
         return metadataapi.download_file(url, file, config)
-    
+
     def get_user_info(self, config: NamerConfig) -> Optional[dict]:
         """
         Get user information from ThePornDB using GraphQL.
         """
-        user_query = '''
+        user_query = """
             query GetUser {
                 me {
                     id
                     name
                 }
             }
-        '''
-        
+        """
+
         response_data = self._graphql_request(user_query, {}, config)
-        
+
         if response_data and 'me' in response_data:
             return response_data['me']
 
@@ -555,13 +521,13 @@ class ThePornDBProvider(BaseMetadataProvider):
 def _build_graphql_query(query_type: str, variables: Dict[str, Any]) -> Dict[str, Any]:
     """
     Build a GraphQL query for ThePornDB.
-    
+
     This is a placeholder for future GraphQL implementation.
     For now, we continue to use the REST API.
     """
     # TODO: Implement GraphQL queries when migrating from REST
     queries = {
-        'searchScene': '''
+        'searchScene': """
             query SearchScene($term: String!) {
                 searchScene(term: $term) {
                     id
@@ -602,8 +568,8 @@ def _build_graphql_query(query_type: str, variables: Dict[str, Any]) -> Dict[str
                     }
                 }
             }
-        ''',
-        'getScene': '''
+        """,
+        'getScene': """
             query GetScene($id: ID!) {
                 findScene(id: $id) {
                     id
@@ -645,10 +611,7 @@ def _build_graphql_query(query_type: str, variables: Dict[str, Any]) -> Dict[str
                     }
                 }
             }
-        '''
+        """,
     }
-    
-    return {
-        'query': queries.get(query_type, ''),
-        'variables': variables
-    }
+
+    return {'query': queries.get(query_type, ''), 'variables': variables}

--- a/namer/metadataapi.py
+++ b/namer/metadataapi.py
@@ -435,7 +435,18 @@ def __metadataapi_response_to_data(json_object: dict, url: str, json_response: s
     return file_infos
 
 
-def __build_url(namer_config: NamerConfig, site: Optional[str] = None, release_date: Optional[str] = None, name: Optional[str] = None, uuid: Optional[str] = None, page: Optional[int] = None, scene_type: Optional[SceneType] = None, phash: Optional[PerceptualHash] = None, add_to_collection: Optional[bool] = None, user: Optional[bool] = None) -> Optional[str]:
+def __build_url(
+    namer_config: NamerConfig,
+    site: Optional[str] = None,
+    release_date: Optional[str] = None,
+    name: Optional[str] = None,
+    uuid: Optional[str] = None,
+    page: Optional[int] = None,
+    scene_type: Optional[SceneType] = None,
+    phash: Optional[PerceptualHash] = None,
+    add_to_collection: Optional[bool] = None,
+    user: Optional[bool] = None,
+) -> Optional[str]:
     query = ''
     if uuid:
         query = uuid
@@ -527,7 +538,7 @@ def get_complete_metadataapi_net_fileinfo(name_parts: Optional[FileInfo], uuid: 
 def _match_legacy_theporndb(file_name_parts: Optional[FileInfo], namer_config: NamerConfig, phash: Optional[PerceptualHash] = None) -> ComparisonResults:
     """
     Legacy ThePornDB matching logic (original REST API implementation).
-    
+
     DEPRECATED: This function is maintained for backward compatibility only.
     New code should use the GraphQL-based ThePornDBProvider instead.
     """
@@ -560,12 +571,12 @@ def match(file_name_parts: Optional[FileInfo], namer_config: NamerConfig, phash:
     """
     Give parsed file name parts, and a provider token, returns a sorted list of possible matches.
     Matches will appear first.
-    
+
     This function routes to the appropriate metadata provider based on configuration.
     """
     # Get the appropriate provider based on configuration
     provider = get_metadata_provider(namer_config)
-    
+
     # Use provider-specific matching logic
     return provider.match(file_name_parts, namer_config, phash)
 
@@ -574,6 +585,7 @@ def toggle_collected(metadata: LookedUpFileInfo, config: NamerConfig):
     """Toggle collection status for a scene using the configured provider."""
     if metadata.uuid and config.metadata_provider.lower() == 'theporndb':
         from namer.metadata_providers.theporndb_provider import ThePornDBProvider
+
         provider = ThePornDBProvider()
         scene_id = metadata.uuid.rsplit('/', 1)[-1]
         provider._mark_collected(scene_id, config)
@@ -583,6 +595,7 @@ def share_hash(metadata: LookedUpFileInfo, scene_hash: SceneHash, config: NamerC
     """Share a hash for a scene using the configured provider."""
     if metadata.uuid and config.metadata_provider.lower() == 'theporndb':
         from namer.metadata_providers.theporndb_provider import ThePornDBProvider
+
         provider = ThePornDBProvider()
         scene_id = metadata.uuid.rsplit('/', 1)[-1]
         provider._share_hash(scene_id, scene_hash, config)

--- a/namer/namer.py
+++ b/namer/namer.py
@@ -178,7 +178,7 @@ def process_file(command: Command) -> Optional[Command]:
             if new_metadata is not None:
                 new_metadata.original_parsed_filename = command.parsed_file
             else:
-                logger.error('Could not process files: {}\nIn the file\'s name should start with a site, a date and end with an extension', command.input_file)
+                logger.error("Could not process files: {}\nIn the file's name should start with a site, a date and end with an extension", command.input_file)
         # elif new_metadata is None and command.stashdb_id is not None and command.ff_probe_results is not None:
         #    phash = VideoPerceptualHash().get_phash(command.target_movie_file)
         #    todo use phash
@@ -244,7 +244,7 @@ def process_file(command: Command) -> Optional[Command]:
         if new_metadata is not None:
             # Ensure the original parsed filename extension matches the current file extension
             # This handles both container conversion and cases where filename parsing failed to extract extension
-            if (new_metadata.original_parsed_filename and command.target_movie_file):
+            if new_metadata.original_parsed_filename and command.target_movie_file:
                 actual_extension = command.target_movie_file.suffix.lower()[1:]
                 parsed_extension = new_metadata.original_parsed_filename.extension
                 # Update if extension is None, empty, or different from actual file extension
@@ -348,9 +348,7 @@ def send_webhook_notification(video_file: Path, config: NamerConfig):
         'Content-Type': 'application/json',
     }
 
-    data = orjson.dumps({
-        'target_movie_file': str(video_file)
-    })
+    data = orjson.dumps({'target_movie_file': str(video_file)})
 
     response = None
     try:

--- a/namer/videophash/videophash.py
+++ b/namer/videophash/videophash.py
@@ -23,9 +23,7 @@ class VideoPerceptualHash:
     def __init__(self, ffmpeg: FFMpeg):
         self.__ffmpeg = ffmpeg
 
-    def get_hashes(self, file: Path, max_workers: Optional[int] = None, use_gpu: bool = False,
-                   hwaccel_backend: Optional[str] = None, hwaccel_device: Optional[str] = None,
-                   hwaccel_decoder: Optional[str] = None) -> Optional[PerceptualHash]:
+    def get_hashes(self, file: Path, max_workers: Optional[int] = None, use_gpu: bool = False, hwaccel_backend: Optional[str] = None, hwaccel_device: Optional[str] = None, hwaccel_decoder: Optional[str] = None) -> Optional[PerceptualHash]:
         data = None
 
         probe = self.__ffmpeg.ffprobe(file)
@@ -41,21 +39,17 @@ class VideoPerceptualHash:
 
         return data
 
-    def get_phash(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool,
-                  hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str]) -> Optional[imagehash.ImageHash]:
+    def get_phash(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool, hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str]) -> Optional[imagehash.ImageHash]:
         stat = file.stat()
         return self._get_phash(file, duration, max_workers, use_gpu, hwaccel_backend, hwaccel_device, hwaccel_decoder, stat.st_size, stat.st_mtime)
 
     @lru_cache(maxsize=1024)  # noqa: B019
-    def _get_phash(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool,
-                   hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str],
-                   file_size: int, file_update: float) -> Optional[imagehash.ImageHash]:
+    def _get_phash(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool, hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str], file_size: int, file_update: float) -> Optional[imagehash.ImageHash]:
         logger.info(f'Calculating phash for file "{file}"')
         phash = self.__calculate_phash(file, duration, max_workers, use_gpu, hwaccel_backend, hwaccel_device, hwaccel_decoder)
         return phash
 
-    def __calculate_phash(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool,
-                          hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str]) -> Optional[imagehash.ImageHash]:
+    def __calculate_phash(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool, hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str]) -> Optional[imagehash.ImageHash]:
         phash = None
 
         thumbnail_image = self.__generate_image_thumbnail(file, duration, max_workers, use_gpu, hwaccel_backend, hwaccel_device, hwaccel_decoder)
@@ -64,8 +58,7 @@ class VideoPerceptualHash:
 
         return phash
 
-    def __generate_image_thumbnail(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool,
-                                   hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str]) -> Optional[Image.Image]:
+    def __generate_image_thumbnail(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool, hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str]) -> Optional[Image.Image]:
         thumbnail_image = None
 
         thumbnail_list = self.__generate_thumbnails(file, duration, max_workers, use_gpu, hwaccel_backend, hwaccel_device, hwaccel_decoder)
@@ -84,8 +77,7 @@ class VideoPerceptualHash:
         file_hash = oshash.oshash(str(file))
         return file_hash
 
-    def __generate_thumbnails(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool,
-                              hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str]) -> List[Image.Image]:
+    def __generate_thumbnails(self, file: Path, duration: float, max_workers: Optional[int], use_gpu: bool, hwaccel_backend: Optional[str], hwaccel_device: Optional[str], hwaccel_decoder: Optional[str]) -> List[Image.Image]:
         duration = int(Decimal(duration * 100).quantize(0, ROUND_HALF_UP)) / 100
 
         chunk_count = self.__columns * self.__rows

--- a/namer/web/actions.py
+++ b/namer/web/actions.py
@@ -142,26 +142,26 @@ def get_search_results(query: str, search_type: SearchType, file: str, config: N
     """
     provider = get_metadata_provider(config)
     all_results = []
-    
+
     # Search different content types based on search_type
     if search_type == SearchType.ANY or search_type == SearchType.SCENES:
         scene_results = provider.search(query, SceneType.SCENE, config, page)
         all_results.extend(scene_results)
-    
+
     if search_type == SearchType.ANY or search_type == SearchType.MOVIES:
         movie_results = provider.search(query, SceneType.MOVIE, config, page)
         all_results.extend(movie_results)
-    
+
     if search_type == SearchType.ANY or search_type == SearchType.JAV:
         jav_results = provider.search(query, SceneType.JAV, config, page)
         all_results.extend(jav_results)
-    
+
     # Convert LookedUpFileInfo objects to web UI format
     files = []
     for scene_data in all_results:
         # Parse the file name for comparison
         name_parts = parse_file_name(query, config)
-        
+
         # Create a basic comparison result for the web UI
         scene = {
             'name_parts': name_parts,
@@ -183,7 +183,7 @@ def get_search_results(query: str, search_type: SearchType, file: str, config: N
             'phash_duration': None,
         }
         files.append(scene)
-    
+
     return {
         'file': file,
         'files': files,
@@ -203,11 +203,11 @@ def get_phash_results(file: str, search_type: SearchType, config: NamerConfig) -
         return {'file': file, 'files': []}
 
     provider = get_metadata_provider(config)
-    
+
     # Use the provider's match function with phash for better results
     name_parts = parse_file_name(file, config)
     comparison_results = provider.match(name_parts, config, phash)
-    
+
     # Convert ComparisonResults to web UI format
     files = []
     for result in comparison_results.results:
@@ -230,7 +230,7 @@ def get_phash_results(file: str, search_type: SearchType, config: NamerConfig) -
             'phash_duration': result.phash_duration,
         }
         files.append(scene)
-    
+
     return {
         'file': file,
         'files': files,

--- a/namer/web/server.py
+++ b/namer/web/server.py
@@ -200,10 +200,7 @@ def default(obj):
         return float(obj)
 
     elif isinstance(obj, (numpy.complex64, numpy.complex128)):
-        return {
-            'real': obj.real,
-            'imag': obj.imag
-        }
+        return {'real': obj.real, 'imag': obj.imag}
 
     elif isinstance(obj, (numpy.ndarray,)):
         return obj.tolist()

--- a/scripts/build-orbstack.sh
+++ b/scripts/build-orbstack.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Lightweight build wrapper used by Makefile targets
+# Usage: build-orbstack.sh <fast|full|dev> <image_name> <version>
+set -Eeuo pipefail
+
+MODE="${1:-fast}"
+IMAGE_NAME="${2:-nehpz/namer}"
+VERSION="${3:-latest}"
+
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+GIT_HASH=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+PROJECT_VERSION=$(grep -E 'version\s*=\s*"' pyproject.toml 2>/dev/null | head -1 | cut -d'"' -f2 || echo "dev")
+
+COMMON_ARGS=(
+  -f Dockerfile \
+  --build-arg BUILD_DATE="$BUILD_DATE" \
+  --build-arg GIT_HASH="$GIT_HASH" \
+  --build-arg PROJECT_VERSION="$PROJECT_VERSION" \
+  -t "$IMAGE_NAME:$VERSION" \
+  -t "$IMAGE_NAME:latest" \
+  .
+)
+
+echo "[build-orbstack] Mode: $MODE"
+echo "[build-orbstack] Image: $IMAGE_NAME:$VERSION"
+echo "[build-orbstack] Build date: $BUILD_DATE"
+echo "[build-orbstack] Git hash: $GIT_HASH"
+echo "[build-orbstack] Project version: $PROJECT_VERSION"
+
+case "$MODE" in
+  fast)
+    docker build "${COMMON_ARGS[@]}"
+    ;;
+  full)
+    if [[ -x ./validate.sh ]]; then
+      echo "[build-orbstack] Running validation before full build..."
+      ./validate.sh
+    fi
+    docker build --no-cache "${COMMON_ARGS[@]}"
+    ;;
+  dev)
+    # If your Dockerfile has a dedicated builder stage, feel free to add --target here.
+    docker build --progress=plain "${COMMON_ARGS[@]}"
+    ;;
+  *)
+    echo "Usage: $0 <fast|full|dev> <image_name> <version>" >&2
+    exit 2
+    ;;
+ esac

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Cleanup helper used by Makefile 'clean' and 'clean-deep' targets
+# Usage: cleanup.sh <light|medium|deep>
+set -Eeuo pipefail
+
+MODE="${1:-medium}"
+
+log() { echo "[cleanup] $*"; }
+
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require docker
+
+case "$MODE" in
+  light)
+    log "Pruning stopped containers and dangling images (light)"
+    docker container prune -f || true
+    docker image prune -f || true
+    ;;
+  medium)
+    log "Pruning containers, images, and builder cache (medium)"
+    docker container prune -f || true
+    docker image prune -f || true
+    docker builder prune -f || true
+    ;;
+  deep)
+    log "Performing deep prune of all unused data (deep)"
+    docker system prune -af || true
+    docker volume prune -f || true
+    ;;
+  *)
+    echo "Usage: $0 <light|medium|deep>" >&2
+    exit 2
+    ;;
+ esac
+
+log "Cleanup complete"

--- a/scripts/detect-intel-gpu.sh
+++ b/scripts/detect-intel-gpu.sh
@@ -20,8 +20,10 @@ get_pci_info() {
     card_device="${card_device/131/3}"
     
     if [[ -e "/sys/class/drm/${card_device}/device/vendor" && -e "/sys/class/drm/${card_device}/device/device" ]]; then
-        local vendor=$(cat "/sys/class/drm/${card_device}/device/vendor" 2>/dev/null || echo "unknown")
-        local device=$(cat "/sys/class/drm/${card_device}/device/device" 2>/dev/null || echo "unknown")
+        local vendor
+        vendor=$(cat "/sys/class/drm/${card_device}/device/vendor" 2>/dev/null || echo "unknown")
+        local device
+        device=$(cat "/sys/class/drm/${card_device}/device/device" 2>/dev/null || echo "unknown")
         echo "${vendor}:${device}"
     else
         echo "unknown:unknown"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Install Git hooks using pre-commit for this repository.
+# - pre-commit: fast checks (ruff, etc.) on staged files
+# - pre-push: run validate.sh --fast
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+cd "$ROOT_DIR"
+
+log() { echo "[install-hooks] $*"; }
+
+have_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+run_pre_commit() {
+  if have_cmd poetry && poetry run pre-commit --version >/dev/null 2>&1; then
+    poetry run pre-commit "$@"
+  elif have_cmd pre-commit; then
+    pre-commit "$@"
+  else
+    log "pre-commit is not installed. Install via one of:";
+    log "  - poetry add --group dev pre-commit";
+    log "  - pipx install pre-commit";
+    log "  - python3 -m pip install --user pre-commit";
+    exit 1
+  fi
+}
+
+log "Installing pre-commit hooks..."
+run_pre_commit install
+
+log "Installing pre-push hook..."
+run_pre_commit install --hook-type pre-push
+
+log "Hooks installed. Verifying configuration..."
+run_pre_commit validate-config || { log "Invalid .pre-commit-config.yaml"; exit 1; }
+
+log "Done. You can test hooks with: pre-commit run -a"

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Basic/integration test runner used by Makefile
+# Usage: test-docker.sh <image_name> <version> <basic|integration>
+set -Eeuo pipefail
+
+IMAGE_NAME="${1:-nehpz/namer}"
+VERSION="${2:-latest}"
+MODE="${3:-basic}"
+
+IMAGE_REF="${IMAGE_NAME}:${VERSION}"
+
+log() { echo "[test-docker] $*"; }
+
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require docker
+
+log "Testing image: ${IMAGE_REF} (mode=${MODE})"
+
+# Sanity: ensure image is present locally; if not, try to pull
+if ! docker image inspect "${IMAGE_REF}" >/dev/null 2>&1; then
+  log "Image not found locally; attempting pull..."
+  docker pull "${IMAGE_REF}" >/dev/null
+fi
+
+# 1) Sanity check: Python available inside image
+log "Checking Python presence..."
+docker run --rm --entrypoint bash "${IMAGE_REF}" -lc 'python3 --version' >/dev/null
+
+# 2) Sanity check: gosu present (entrypoint uses it)
+log "Checking gosu presence..."
+docker run --rm --entrypoint bash "${IMAGE_REF}" -lc 'command -v gosu' >/dev/null
+
+# 3) Sanity check: entrypoint exists
+log "Checking entrypoint file exists..."
+docker run --rm --entrypoint bash "${IMAGE_REF}" -lc '[ -f /app/docker-entrypoint-user.sh ]' >/dev/null
+
+if [[ "$MODE" == "basic" ]]; then
+  log "Basic checks passed"
+  exit 0
+fi
+
+# Integration: run a lightweight dry-run that exercises entrypoint without long-running service
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+log "Running container with minimal env to verify startup path..."
+# Use a short no-op command through bash to avoid long-running watchdog
+# and to ensure entrypoint completes crucial setup steps and hands off.
+docker run --rm \
+  -e PUID=1000 -e PGID=1000 -e UMASK=0002 \
+  -e NAMER_CONFIG=/config/namer.cfg \
+  -v "$TMPDIR:/config" \
+  --device /dev/null:/dev/null \
+  --entrypoint bash \
+  "${IMAGE_REF}" -lc 'echo ok' >/dev/null
+
+log "Integration checks passed"

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -38,7 +38,7 @@ docker run --rm --entrypoint bash "${IMAGE_REF}" -lc 'command -v gosu' >/dev/nul
 
 # 3) Sanity check: entrypoint exists
 log "Checking entrypoint file exists..."
-docker run --rm --entrypoint bash "${IMAGE_REF}" -lc '[ -f /app/docker-entrypoint-user.sh ]' >/dev/null
+docker run --rm --entrypoint bash "${IMAGE_REF}" -lc '[ -f /usr/local/bin/docker-entrypoint.sh ] || [ -f /app/docker-entrypoint-user.sh ]' >/dev/null
 
 if [[ "$MODE" == "basic" ]]; then
   log "Basic checks passed"

--- a/test/disambiguation_test.py
+++ b/test/disambiguation_test.py
@@ -2,82 +2,82 @@ from namer.disambiguation import Candidate, decide, Decision
 
 
 DEFAULTS = {
-    "accept_distance": 6,
-    "ambiguous_min": 7,
-    "ambiguous_max": 12,
-    "distance_margin_accept": 3,
-    "majority_accept_fraction": 0.7,
+    'accept_distance': 6,
+    'ambiguous_min': 7,
+    'ambiguous_max': 12,
+    'distance_margin_accept': 3,
+    'majority_accept_fraction': 0.7,
 }
 
 
 def test_accept_single_candidate_under_accept_distance():
-    cands = [Candidate(guid="A", phash_distance=5)]  # <= accept_distance
+    cands = [Candidate(guid='A', phash_distance=5)]  # <= accept_distance
     guid, decision = decide(cands, **DEFAULTS)
     assert decision == Decision.ACCEPT
-    assert guid == "A"
+    assert guid == 'A'
 
 
 def test_ambiguous_when_majority_guid_differs_from_best():
     # best=5 for A, but B holds majority (3/4 = 0.75) >= 0.7 -> should NOT accept since majority_guid != best
     cands = [
-        Candidate(guid="A", phash_distance=5),
-        Candidate(guid="B", phash_distance=6),
-        Candidate(guid="B", phash_distance=6),
-        Candidate(guid="B", phash_distance=6),
+        Candidate(guid='A', phash_distance=5),
+        Candidate(guid='B', phash_distance=6),
+        Candidate(guid='B', phash_distance=6),
+        Candidate(guid='B', phash_distance=6),
     ]
     guid, decision = decide(cands, **DEFAULTS)
     assert decision == Decision.AMBIGUOUS
-    assert guid == ""
+    assert guid == ''
 
 
 def test_accept_with_distance_margin():
     # best=5, second=9 -> margin 4 >= 3 -> accept best
     cands = [
-        Candidate(guid="A", phash_distance=5),
-        Candidate(guid="B", phash_distance=9),
-        Candidate(guid="C", phash_distance=12),
+        Candidate(guid='A', phash_distance=5),
+        Candidate(guid='B', phash_distance=9),
+        Candidate(guid='C', phash_distance=12),
     ]
     guid, decision = decide(cands, **DEFAULTS)
     assert decision == Decision.ACCEPT
-    assert guid == "A"
+    assert guid == 'A'
 
 
 def test_ambiguous_when_no_margin_and_no_majority():
     # best=5, second=6 -> margin 1 < 3, majority fraction: top guid count 1 of 3 -> 0.333 < 0.7 -> ambiguous
     cands = [
-        Candidate(guid="A", phash_distance=5),
-        Candidate(guid="B", phash_distance=6),
-        Candidate(guid="C", phash_distance=6),
+        Candidate(guid='A', phash_distance=5),
+        Candidate(guid='B', phash_distance=6),
+        Candidate(guid='C', phash_distance=6),
     ]
     guid, decision = decide(cands, **DEFAULTS)
     assert decision == Decision.AMBIGUOUS
-    assert guid == ""
+    assert guid == ''
 
 
 def test_accept_when_no_margin_but_majority_fraction_met():
     # best=5, second=6 -> margin 1 < 3, but majority guid fraction is 0.75 -> accept best
     cands = [
-        Candidate(guid="A", phash_distance=5),
-        Candidate(guid="A", phash_distance=6),
-        Candidate(guid="A", phash_distance=6),
-        Candidate(guid="B", phash_distance=6),
+        Candidate(guid='A', phash_distance=5),
+        Candidate(guid='A', phash_distance=6),
+        Candidate(guid='A', phash_distance=6),
+        Candidate(guid='B', phash_distance=6),
     ]
     guid, decision = decide(cands, **DEFAULTS)
     assert decision == Decision.ACCEPT
-    assert guid == "A"
+    assert guid == 'A'
 
 
 def test_ambiguous_when_best_in_ambiguous_band():
     # best=9 in [7,12] -> ambiguous
-    cands = [Candidate(guid="X", phash_distance=9)]
+    cands = [Candidate(guid='X', phash_distance=9)]
     guid, decision = decide(cands, **DEFAULTS)
     assert decision == Decision.AMBIGUOUS
-    assert guid == ""
+    assert guid == ''
 
 
 def test_reject_when_best_beyond_ambiguous_band():
     # best=20 > 12 -> reject
-    cands = [Candidate(guid="X", phash_distance=20)]
+    cands = [Candidate(guid='X', phash_distance=20)]
     guid, decision = decide(cands, **DEFAULTS)
     assert decision == Decision.REJECT
-    assert guid == ""
+    assert guid == ''

--- a/test/namer_ffmpeg_test.py
+++ b/test/namer_ffmpeg_test.py
@@ -17,6 +17,7 @@ class UnitTestAsTheDefaultExecution(unittest.TestCase):
     """
     Always test first.
     """
+
     def __init__(self, method_name='runTest'):
         super().__init__(method_name)
 

--- a/test/namer_videophash_test.py
+++ b/test/namer_videophash_test.py
@@ -51,7 +51,7 @@ class UnitTestAsTheDefaultExecution(unittest.TestCase):
                 self.assertEqual(res.oshash, expected_oshash)
                 self.assertEqual(res.duration, expected_duration)
 
-    @unittest.skipIf(True, "StashVideoPerceptualHash requires external binary not available in test environment")
+    @unittest.skipIf(True, 'StashVideoPerceptualHash requires external binary not available in test environment')
     def test_get_stash_phash(self):
         """
         Test phash calculation.
@@ -71,8 +71,6 @@ class UnitTestAsTheDefaultExecution(unittest.TestCase):
                 self.assertEqual(res.phash, expected_phash)
                 self.assertEqual(res.oshash, expected_oshash)
                 self.assertEqual(res.duration, expected_duration)
-
-
 
 
 if __name__ == '__main__':

--- a/test/utils.py
+++ b/test/utils.py
@@ -173,7 +173,9 @@ class FakeTPDB(ParrotWebServer):
         self.add_evil_angel('/movies?parse=EvilAngel%20-%202022-01-03%20-%20Carmela%20Clutch%20Fabulous%20Anal%203-Way%21&limit=25')
         # Image for UI Test:
         self.add_evil_angel('/scenes?parse=EvilAngel.-.2022-01-03.-.Carmela.Clutch.Fabulous.Anal.3-Way%21.mp4&limit=25')
-        self.add_poster('/qWAUIAUpBsoqKUwozc4NOTR1tPI=/1000x1500/smart/filters:sharpen():upscale():watermark(https://cdn.metadataapi.net/sites/3f/9f/51/cf3828d65425bca2890d53ef242d8cf/logo/evil-angel_dark[1].png,-10,-10,25,50)/https://cdn.metadataapi.net/scene/f4/ab/3e/a91d31d6dee223f4f30a57bfd83b151/background/bg-evil-angel-carmela-clutch-fabulous-anal-3-way.webp?')
+        self.add_poster(
+            '/qWAUIAUpBsoqKUwozc4NOTR1tPI=/1000x1500/smart/filters:sharpen():upscale():watermark(https://cdn.metadataapi.net/sites/3f/9f/51/cf3828d65425bca2890d53ef242d8cf/logo/evil-angel_dark[1].png,-10,-10,25,50)/https://cdn.metadataapi.net/scene/f4/ab/3e/a91d31d6dee223f4f30a57bfd83b151/background/bg-evil-angel-carmela-clutch-fabulous-anal-3-way.webp?'
+        )
         # DorcelClub
         # Search Results
         self.add_dorcel_club('/scenes?parse=dorcelclub.2021-12-23.Aya%20Benetti%20Megane%20Lopez%20And%20Bella%20Tina&limit=25')
@@ -206,21 +208,21 @@ class FakeTPDB(ParrotWebServer):
 
         self.add_json_response('{"data":{"favicon":null,"id":1309,"logo":null,"name":"Gamma Enterprises","network_id":null,"parent_id":null,"poster":null,"short_name":"gammaenterprises","url":"N/A"}}', '/sites/1309?')
         self.add_json_response('{"data":{"id":1,"name":"Admin"}}', '/auth/user?')
-    
+
     def setup_graphql_endpoint(self):
         """Set up GraphQL endpoint that handles POST requests."""
         from flask import request as flask_request
-        
+
         def handle_graphql_request():
             """Handle GraphQL POST request and return appropriate response."""
             try:
                 import orjson
-                
+
                 # Parse the GraphQL request
                 request_data = orjson.loads(flask_request.get_data())
                 query = request_data.get('query', '')
                 variables = request_data.get('variables', {})
-                
+
                 # Route based on query type
                 if 'searchScenes' in query:
                     return self._handle_search_scenes(variables)
@@ -235,23 +237,21 @@ class FakeTPDB(ParrotWebServer):
                 elif 'shareSceneHash' in query:
                     return self._handle_share_hash(variables)
                 else:
-                    return orjson.dumps({"data": None}).decode('utf-8')
-                    
+                    return orjson.dumps({'data': None}).decode('utf-8')
+
             except Exception as e:
-                return orjson.dumps({
-                    "errors": [{"message": f"GraphQL error: {str(e)}"}]
-                }).decode('utf-8')
-        
+                return orjson.dumps({'errors': [{'message': f'GraphQL error: {str(e)}'}]}).decode('utf-8')
+
         # Set up the GraphQL endpoint - handle both with and without query params
         super().set_response('/graphql', handle_graphql_request)
         super().set_response('/graphql?', handle_graphql_request)
-    
+
     def _handle_search_scenes(self, variables):
         """Handle searchScenes GraphQL query (legacy)."""
         import orjson
-        
+
         query_string = variables.get('query', '').lower()
-        
+
         # Determine which scene data to return based on query
         if 'evilangel' in query_string and 'carmela clutch' in query_string:
             # ea.full.json has the scene data directly in 'data' field
@@ -261,32 +261,20 @@ class FakeTPDB(ParrotWebServer):
             scene_data = self._scenes['dc.json']['data'][0]
         elif 'brazzersexxtra' in query_string and 'marykate moss' in query_string:
             # ssb2.json has REST API structure with 'data' array
-            scene_data = self._scenes['ssb2.json']['data'][0]  
+            scene_data = self._scenes['ssb2.json']['data'][0]
         else:
             # Return empty results for unknown queries
-            return orjson.dumps({
-                "data": {
-                    "searchScenes": {
-                        "data": []
-                    }
-                }
-            }).decode('utf-8')
-        
+            return orjson.dumps({'data': {'searchScenes': {'data': []}}}).decode('utf-8')
+
         # Wrap single scene in GraphQL searchScenes response format
-        return orjson.dumps({
-            "data": {
-                "searchScenes": {
-                    "data": [scene_data]
-                }
-            }
-        }).decode('utf-8')
-        
+        return orjson.dumps({'data': {'searchScenes': {'data': [scene_data]}}}).decode('utf-8')
+
     def _handle_search_scene(self, variables):
         """Handle searchScene GraphQL query (singular, current schema)."""
         import orjson
-        
+
         term_string = variables.get('term', '').lower()
-        
+
         # Determine which scene data to return based on term
         if 'evilangel' in term_string and 'carmela clutch' in term_string:
             # ea.full.json has the scene data directly in 'data' field
@@ -296,28 +284,20 @@ class FakeTPDB(ParrotWebServer):
             scene_data = self._scenes['dc.json']['data'][0]
         elif 'brazzersexxtra' in term_string and 'marykate moss' in term_string:
             # ssb2.json has REST API structure with 'data' array
-            scene_data = self._scenes['ssb2.json']['data'][0]  
+            scene_data = self._scenes['ssb2.json']['data'][0]
         else:
             # Return empty results for unknown queries
-            return orjson.dumps({
-                "data": {
-                    "searchScene": []
-                }
-            }).decode('utf-8')
-        
+            return orjson.dumps({'data': {'searchScene': []}}).decode('utf-8')
+
         # Return array of scenes for searchScene (current schema)
-        return orjson.dumps({
-            "data": {
-                "searchScene": [scene_data]
-            }
-        }).decode('utf-8')
-    
+        return orjson.dumps({'data': {'searchScene': [scene_data]}}).decode('utf-8')
+
     def _handle_find_scene(self, variables):
         """Handle findScene GraphQL query."""
         import orjson
-        
+
         scene_id = variables.get('id', '')
-        
+
         # Map scene IDs to the appropriate test data
         scene_data = None
         if scene_id == '1678283':
@@ -329,61 +309,43 @@ class FakeTPDB(ParrotWebServer):
         elif scene_id == '1836175':
             # ssb2.json has REST API structure with 'data' array
             scene_data = self._scenes['ssb2.json']['data'][0]
-        
+
         if scene_data:
             # Add isCollected field for complete scene info
             scene_data = scene_data.copy()  # Create copy to avoid modifying original
             scene_data['isCollected'] = False
-            
-        return orjson.dumps({
-            "data": {
-                "findScene": scene_data
-            }
-        }).decode('utf-8')
-    
+
+        return orjson.dumps({'data': {'findScene': scene_data}}).decode('utf-8')
+
     def _handle_user_info(self):
         """Handle user info GraphQL query."""
         import orjson
-        
-        return orjson.dumps({
-            "data": {
-                "me": {
-                    "id": "1",
-                    "name": "testuser",  # Use 'name' to match legacy format expectation
-                    "email": "test@example.com",
-                    "isAdmin": True,
-                    "collectedScenes": {
-                        "totalCount": 0
+
+        return orjson.dumps(
+            {
+                'data': {
+                    'me': {
+                        'id': '1',
+                        'name': 'testuser',  # Use 'name' to match legacy format expectation
+                        'email': 'test@example.com',
+                        'isAdmin': True,
+                        'collectedScenes': {'totalCount': 0},
                     }
                 }
             }
-        }).decode('utf-8')
-    
+        ).decode('utf-8')
+
     def _handle_mark_collected(self, variables):
         """Handle markSceneCollected GraphQL mutation."""
         import orjson
-        
-        return orjson.dumps({
-            "data": {
-                "markSceneCollected": {
-                    "success": True,
-                    "message": "Scene marked as collected"
-                }
-            }
-        }).decode('utf-8')
-    
+
+        return orjson.dumps({'data': {'markSceneCollected': {'success': True, 'message': 'Scene marked as collected'}}}).decode('utf-8')
+
     def _handle_share_hash(self, variables):
         """Handle shareSceneHash GraphQL mutation."""
         import orjson
-        
-        return orjson.dumps({
-            "data": {
-                "shareSceneHash": {
-                    "success": True,
-                    "message": "Hash shared successfully"
-                }
-            }
-        }).decode('utf-8')
+
+        return orjson.dumps({'data': {'shareSceneHash': {'success': True, 'message': 'Hash shared successfully'}}}).decode('utf-8')
 
 
 @contextlib.contextmanager
@@ -395,7 +357,7 @@ def environment(config: NamerConfig = None):  # type: ignore
         temp_dir = Path(tmp_dir).resolve()
 
         config.enabled_tagging = True
-        config.metadata_provider = "theporndb"
+        config.metadata_provider = 'theporndb'
         config.enabled_poster = True
         config.override_tpdb_address = fake_tpdb.get_url()
         config.watch_dir = temp_dir / 'watch'
@@ -434,7 +396,7 @@ def environment_stashdb(config: NamerConfig = None):  # type: ignore
 
         # Point endpoint to fake server's /graphql and set a dummy token
         base = fake_stash.get_url()
-        config.stashdb_endpoint = f"{base}/graphql"
+        config.stashdb_endpoint = f'{base}/graphql'
         config.stashdb_token = 'notarealtoken'
 
         # Standard directories
@@ -561,14 +523,15 @@ def new_ea(target_dir: Optional[Path] = None, relative: str = '', use_dir: bool 
 
 # --- Disambiguation test helpers ---
 
-def create_dummy_video(tmp_path: Path, subdir: str = "src", filename: str = "video.mp4") -> Path:
+
+def create_dummy_video(tmp_path: Path, subdir: str = 'src', filename: str = 'video.mp4') -> Path:
     """
     Create a small dummy video file under tmp_path/subdir.
     """
     src = tmp_path / subdir
     src.mkdir(parents=True, exist_ok=True)
     video = src / filename
-    video.write_bytes(b"x")
+    video.write_bytes(b'x')
     return video
 
 
@@ -578,7 +541,7 @@ def setup_disambiguation_config(tmp_path: Path, enable_flag: bool) -> tuple[Name
     Returns (config, ambiguous_dir).
     """
     cfg = sample_config()
-    ambiguous_dir = tmp_path / "ambiguous"
+    ambiguous_dir = tmp_path / 'ambiguous'
     ambiguous_dir.mkdir()
 
     cfg.enable_disambiguation = enable_flag
@@ -599,7 +562,7 @@ def patch_default_ambiguous_match(monkeypatch) -> None:
             info = LookedUpFileInfo()
             info.guid = guid
             return ComparisonResult(
-                name="n",
+                name='n',
                 name_match=95.0,
                 site_match=True,
                 date_match=True,
@@ -609,10 +572,10 @@ def patch_default_ambiguous_match(monkeypatch) -> None:
                 phash_duration=True,
             )
 
-        results = [mk("A", 5), mk("B", 6), mk("B", 6), mk("B", 6)]
+        results = [mk('A', 5), mk('B', 6), mk('B', 6), mk('B', 6)]
         return ComparisonResults(results, None)
 
-    monkeypatch.setattr("namer.metadataapi.match", _fake_match)
+    monkeypatch.setattr('namer.metadataapi.match', _fake_match)
 
 
 def new_dorcel(target_dir: Optional[Path] = None, relative: str = '', use_dir: bool = True, post_stem: str = '', match: bool = True, mp4_file_name: str = 'Site.22.01.01.painful.pun.XXX.720p.xpost.mp4'):

--- a/test/web/fake_stashdb.py
+++ b/test/web/fake_stashdb.py
@@ -7,25 +7,23 @@ def make_fake_stashdb() -> ParrotWebServer:
     # Single sample scene payload reused across handlers
     def sample_scene(base_url: str):
         return {
-            "id": "s1",
-            "title": "Sample Scene",
-            "date": "2022-01-01",
-            "urls": [{"url": "https://example.com/scene/s1"}],
-            "details": "This is a sample StashDB fake scene.",
-            "duration": 600,
-            "images": [{"url": f"{base_url}/poster.png"}],
-            "studio": {
-                "name": "Sample Studio",
-                "parent": {"name": "Sample Network"},
+            'id': 's1',
+            'title': 'Sample Scene',
+            'date': '2022-01-01',
+            'urls': [{'url': 'https://example.com/scene/s1'}],
+            'details': 'This is a sample StashDB fake scene.',
+            'duration': 600,
+            'images': [{'url': f'{base_url}/poster.png'}],
+            'studio': {
+                'name': 'Sample Studio',
+                'parent': {'name': 'Sample Network'},
             },
-            "performers": [
-                {"name": "Actor One", "gender": "FEMALE"},
-                {"name": "Actor Two", "gender": "MALE"},
+            'performers': [
+                {'name': 'Actor One', 'gender': 'FEMALE'},
+                {'name': 'Actor Two', 'gender': 'MALE'},
             ],
-            "tags": [{"name": "Tag1"}, {"name": "Tag2"}],
-            "fingerprints": [
-                {"hash": "abcdef123456", "algorithm": "PHASH", "duration": 600}
-            ],
+            'tags': [{'name': 'Tag1'}, {'name': 'Tag2'}],
+            'fingerprints': [{'hash': 'abcdef123456', 'algorithm': 'PHASH', 'duration': 600}],
         }
 
     def handle_graphql_request():
@@ -34,62 +32,46 @@ def make_fake_stashdb() -> ParrotWebServer:
             from flask import request as flask_request
 
             req = orjson.loads(flask_request.get_data())
-            query: str = req.get("query", "") or ""
-            variables = req.get("variables", {}) or {}
+            query: str = req.get('query', '') or ''
+            variables = req.get('variables', {}) or {}
 
             # Determine response shape
             base_url = server.get_url()
             scene = sample_scene(base_url)
 
-            if "searchScene" in query:
-                return orjson.dumps({
-                    "data": {
-                        "searchScene": [scene]
-                    }
-                }).decode("utf-8")
+            if 'searchScene' in query:
+                return orjson.dumps({'data': {'searchScene': [scene]}}).decode('utf-8')
 
-            if "findScene" in query:
-                scene_id = variables.get("id", "")
-                return orjson.dumps({
-                    "data": {
-                        "findScene": scene if scene_id in ("s1", "1678283") else None
-                    }
-                }).decode("utf-8")
+            if 'findScene' in query:
+                scene_id = variables.get('id', '')
+                return orjson.dumps({'data': {'findScene': scene if scene_id in ('s1', '1678283') else None}}).decode('utf-8')
 
-            if "findSceneByFingerprint" in query or "SearchByFingerprint" in query:
-                fp = variables.get("fingerprint") or {}
-                hash_val = fp.get("hash") or variables.get("hash")
-                data = [scene] if hash_val == "abcdef123456" else []
-                return orjson.dumps({
-                    "data": {
-                        "findSceneByFingerprint": data
-                    }
-                }).decode("utf-8")
+            if 'findSceneByFingerprint' in query or 'SearchByFingerprint' in query:
+                fp = variables.get('fingerprint') or {}
+                hash_val = fp.get('hash') or variables.get('hash')
+                data = [scene] if hash_val == 'abcdef123456' else []
+                return orjson.dumps({'data': {'findSceneByFingerprint': data}}).decode('utf-8')
 
-            if "me" in query:
-                return orjson.dumps({
-                    "data": {
-                        "me": {"id": "u1", "name": "stash-user", "roles": ["USER"]}
-                    }
-                }).decode("utf-8")
+            if 'me' in query:
+                return orjson.dumps({'data': {'me': {'id': 'u1', 'name': 'stash-user', 'roles': ['USER']}}}).decode('utf-8')
 
-            return orjson.dumps({"data": None}).decode("utf-8")
+            return orjson.dumps({'data': None}).decode('utf-8')
         except Exception as e:
             import orjson
-            return orjson.dumps({
-                "errors": [{"message": f"GraphQL error: {str(e)}"}]
-            }).decode("utf-8")
+
+            return orjson.dumps({'errors': [{'message': f'GraphQL error: {str(e)}'}]}).decode('utf-8')
 
     # Register GraphQL endpoint
-    server.set_response("/graphql", handle_graphql_request)
-    server.set_response("/graphql?", handle_graphql_request)
+    server.set_response('/graphql', handle_graphql_request)
+    server.set_response('/graphql?', handle_graphql_request)
 
     # Static poster asset used by tests
     try:
         from pathlib import Path
+
         test_dir = Path(__file__).resolve().parent
-        poster_bytes = (test_dir / "poster.png").read_bytes()
-        server.set_response("/poster.png", bytearray(poster_bytes))
+        poster_bytes = (test_dir / 'poster.png').read_bytes()
+        server.set_response('/poster.png', bytearray(poster_bytes))
     except Exception:
         pass
 

--- a/validate.sh
+++ b/validate.sh
@@ -90,9 +90,9 @@ echo ""
 # Step 5: Local Docker integration test
 echo "5️⃣ Running Docker integration tests..."
 
-cd test_dirs
-
-if [[ -f "./test.sh" ]]; then
+if [[ -d "test/integration" ]] && [[ -f "test/integration/test.sh" ]]; then
+    cd test/integration
+    
     echo "   Setting up test environment..."
     if ./test.sh; then
         echo ""
@@ -117,7 +117,7 @@ if [[ -f "./test.sh" ]]; then
             if echo "$container_logs" | grep -q "ERROR\|CRITICAL\|Exception"; then
                 echo "⚠️  Warning: Found errors in container logs:"
                 echo "$container_logs" | grep -E "ERROR|CRITICAL|Exception" | head -5
-                echo "   Review logs with: cd test_dirs && docker compose logs"
+                echo "   Review logs with: cd test/integration && docker compose logs"
             else
                 echo "✅ No critical errors in startup logs"
             fi
@@ -131,23 +131,21 @@ if [[ -f "./test.sh" ]]; then
             echo "❌ Container startup failed"
             docker compose logs
             docker compose down -v
-            cd ..
+            cd ../..
             exit 1
         fi
     else
         echo "❌ Docker test setup failed"
-        cd ..
+        cd ../..
         exit 1
     fi
+    
+    cd ../..
 else
-    echo "❌ test.sh not found in test_dirs/"
-    cd ..
-    exit 1
+    echo "⚠️  Docker integration tests not configured (test/integration/test.sh missing)"
+    echo "📝 Note: Integration tests are optional for local development"
+    echo "✅ Skipping Docker integration tests"
 fi
-
-cd ..
-echo ""
-
 # Step 6: Final validation
 echo "6️⃣ Final validation summary..."
 echo ""


### PR DESCRIPTION
Summary
- Adopt Python pre-commit as the canonical hook framework for this repo.
- Add `.pre-commit-config.yaml` with fast, high-signal local checks:
  - ruff (lint) and ruff-format
  - shellcheck for shell scripts
  - hadolint for Dockerfile (skips if not installed)
- Add `scripts/install-hooks.sh` to install pre-commit hooks (pre-commit + pre-push).
- Add `make setup-dev` to install hooks easily.
- Enhance `validate.sh` with `--fast` mode to skip slow optional steps (docker integration) for pre-push.
- Fix shellcheck SC2155 in `scripts/detect-intel-gpu.sh` (separate declaration/assignment).

Rationale
- Hooks run automatically to reduce friction and prevent “forgot to lint/test” scenarios.
- Pre-push runs `./validate.sh --fast` for quick feedback; CI runs full checks.
- Aligns with new PR workflows that run lint/tests and container smoke checks.

Notes
- `.husky/` was removed in earlier cleanup; pre-commit is now the single source of truth.
- `make setup-dev` installs both pre-commit and pre-push hooks.
- No behavioral changes to app code beyond formatting and the shellcheck fix; ruff-format applied post-rebase.

Follow-ups (tracked in issues)
- Optional: add mypy/bandit in pre-commit once type coverage solidifies
- Optional: enforce hadolint (remove skip-if-missing)
- CI: security scan & SBOM, required checks, multi-arch smoke on main