### PR TITLE
Bundles videohashes binary in Docker image

### DIFF
--- a/.github/workflows/pr-container-smoke.yml
+++ b/.github/workflows/pr-container-smoke.yml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Healthcheck
         run: |
-          curl -sf http://127.0.0.1:6980/api/healthcheck
+          # Localhost-only health check; HTTPS is not applicable for 127.0.0.1
+          curl --fail --silent --show-error http://127.0.0.1:6980/api/healthcheck
 
       - name: Dump logs on failure
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ARG TARGETARCH
 RUN set -eux; \
   if [ "${TARGETARCH}" = "amd64" ]; then \
     ARCH=$(dpkg --print-architecture); \
-    curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux.gpg; \
+    curl -fsSL --proto '=https' --proto-redir '=https' https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux.gpg; \
     echo "deb [arch=${ARCH} signed-by=/usr/share/keyrings/google-linux.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends google-chrome-stable; \
@@ -72,7 +72,7 @@ RUN pipx install poetry
 RUN set -eux; \
     ARCH=$(dpkg --print-architecture); \
     # Add NodeSource GPG key and repository for Node 22
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; \
+    curl -fsSL --proto '=https' --proto-redir '=https' https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; \
     echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends nodejs; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN set -eux; \
   if [ "${TARGETARCH}" = "amd64" ]; then \
     ARCH=$(dpkg --print-architecture); \
     curl -fsSL --proto '=https' --proto-redir '=https' https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux.gpg; \
-    echo "deb [arch=${ARCH} signed-by=/usr/share/keyrings/google-linux.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list; \
+    echo "deb [arch=${ARCH} signed-by=/usr/share/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends google-chrome-stable; \
   else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,75 +12,75 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies with Intel GPU hardware acceleration support (Intel packages only on amd64)
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       python3-pip \
-       python3 \
-       pipx \
-       ffmpeg \
-       tzdata \
-       curl \
-       wget \
-       gnupg2 \
-       ca-certificates \
-       vainfo \
-       bc \
-       gosu \
-    && if [ "$TARGETARCH" = "amd64" ]; then \
-         apt-get install -y --no-install-recommends \
-           intel-media-va-driver \
-           libmfx-gen1.2 \
-         ; \
-       fi \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
-    && apt-get clean
+  && apt-get install -y --no-install-recommends \
+  python3-pip \
+  python3 \
+  pipx \
+  ffmpeg \
+  tzdata \
+  curl \
+  wget \
+  gnupg2 \
+  ca-certificates \
+  vainfo \
+  bc \
+  gosu \
+  && if [ "$TARGETARCH" = "amd64" ]; then \
+  apt-get install -y --no-install-recommends \
+  intel-media-va-driver \
+  libmfx-gen1.2 \
+  ; \
+  fi \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+  && apt-get clean
 
 FROM base AS build
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       build-essential \
-       libffi-dev \
-       libssl-dev \
-       systemd \
-       systemd-sysv \
-       python3-dev \
-       python3-venv \
-       golang \
-       git \
-       xvfb \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
-    && apt-get clean
+  && apt-get install -y --no-install-recommends \
+  build-essential \
+  libffi-dev \
+  libssl-dev \
+  systemd \
+  systemd-sysv \
+  python3-dev \
+  python3-venv \
+  golang \
+  git \
+  xvfb \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+  && apt-get clean
 
 ENV DISPLAY=:99
 ARG CHROME_VERSION="google-chrome-stable"
 ARG TARGETARCH
 RUN set -eux; \
   if [ "${TARGETARCH}" = "amd64" ]; then \
-    ARCH=$(dpkg --print-architecture); \
-    curl -fsSL --proto '=https' --proto-redir '=https' https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux.gpg; \
-    echo "deb [arch=${ARCH} signed-by=/usr/share/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends google-chrome-stable; \
+  ARCH=$(dpkg --print-architecture); \
+  curl -fsSL --proto '=https' --proto-redir '=https' https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux.gpg; \
+  echo "deb [arch=${ARCH} signed-by=/usr/share/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends google-chrome-stable; \
   else \
-    echo "Skipping Google Chrome installation on ${TARGETARCH}"; \
+  echo "Skipping Google Chrome installation on ${TARGETARCH}"; \
   fi; \
   rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN pipx install poetry
 # Install Node.js (v22) from NodeSource with GPG verification, then pin PNPM 10
 RUN set -eux; \
-    ARCH=$(dpkg --print-architecture); \
-    # Add NodeSource GPG key and repository for Node 22
-    curl -fsSL --proto '=https' --proto-redir '=https' https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; \
-    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends nodejs; \
-    # Verify node version is >= 22
-    node -v; \
-    # Install pnpm with scripts disabled to avoid executing arbitrary lifecycle scripts
-    npm i -g pnpm@10.0.0 --ignore-scripts; \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  ARCH=$(dpkg --print-architecture); \
+  # Add NodeSource GPG key and repository for Node 22
+  curl -fsSL --proto '=https' --proto-redir '=https' https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; \
+  echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends nodejs; \
+  # Verify node version is >= 22
+  node -v; \
+  # Install pnpm with scripts disabled to avoid executing arbitrary lifecycle scripts
+  npm i -g pnpm@10.0.0 --ignore-scripts; \
+  rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN mkdir /work/
 COPY . /work
@@ -101,9 +101,9 @@ WORKDIR /work
 COPY namer/ffmpeg_enhanced.py /work/namer/ffmpeg.py
 
 RUN rm -rf /work/namer/__pycache__/ || true \
-    && rm -rf /work/test/__pycache__/ || true \
-    && poetry lock \
-    && poetry install
+  && rm -rf /work/test/__pycache__/ || true \
+  && poetry lock \
+  && poetry install
 # Build dependencies (node, optional submodule), then fetch videohashes binary, then build package
 RUN bash -lc "( Xvfb :99 & cd /work/ && poetry run poe build_deps )"
 
@@ -116,40 +116,40 @@ ARG PHASH_AMD64_SHA256=dbcc09bd45e260f09dd385e329b041e359fff3bfe66be767070918d51
 # SHA256 for arm64 source tarball at the pinned tag
 ARG PHASH_ARM64_TAR_SHA256=9fa44b290bc32b8173a2efe08f27d4272406b7583de0a6daa72258e42afc2b3f
 RUN set -eux; \
-    cd /work; \
-    mkdir -p namer/tools; \
-    ARCH=$(dpkg --print-architecture); \
-    case "$ARCH" in \
-      amd64) \
-        DOWNLOAD_NAME="videohashes-linux-amd64"; \
-        TARGET_NAME="videohashes-amd64-linux"; \
-        curl --fail --silent --show-error --location \
-             --proto '=https' --proto-redir '=https' \
-             -o "namer/tools/${TARGET_NAME}" \
-             "https://github.com/peolic/videohashes/releases/download/${PHASH_VERSION}/${DOWNLOAD_NAME}"; \
-        echo "${PHASH_AMD64_SHA256}  namer/tools/${TARGET_NAME}" | sha256sum -c -; \
-        chmod +x "namer/tools/${TARGET_NAME}"; \
-        ;; \
-      arm64) \
-        # Build from source tarball for the pinned tag (no repo submodule needed)
-        TMPDIR=$(mktemp -d); \
-        curl --fail --silent --show-error --location \
-             --proto '=https' --proto-redir '=https' \
-             -o "$TMPDIR/videohashes.tar.gz" \
-             "https://github.com/peolic/videohashes/tarball/${PHASH_VERSION}"; \
-        echo "${PHASH_ARM64_TAR_SHA256}  $TMPDIR/videohashes.tar.gz" | sha256sum -c -; \
-        mkdir -p "$TMPDIR/src"; \
-        tar -xzf "$TMPDIR/videohashes.tar.gz" -C "$TMPDIR/src" --strip-components=1; \
-        make -C "$TMPDIR/src" linux-arm64; \
-        cp "$TMPDIR/src/dist/videohashes-arm64-linux" ./namer/tools/; \
-        chmod +x ./namer/tools/videohashes-arm64-linux; \
-        # Sanity check the produced binary looks like an aarch64 ELF
-        file ./namer/tools/videohashes-arm64-linux | grep -E 'ELF 64-bit.*aarch64' >/dev/null; \
-        rm -rf "$TMPDIR"; \
-        ;; \
-      *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
-    esac; \
-    ls -l namer/tools
+  cd /work; \
+  mkdir -p namer/tools; \
+  ARCH=$(dpkg --print-architecture); \
+  case "$ARCH" in \
+  amd64) \
+  DOWNLOAD_NAME="videohashes-linux-amd64"; \
+  TARGET_NAME="videohashes-amd64-linux"; \
+  curl --fail --silent --show-error --location \
+  --proto '=https' --proto-redir '=https' \
+  -o "namer/tools/${TARGET_NAME}" \
+  "https://github.com/peolic/videohashes/releases/download/${PHASH_VERSION}/${DOWNLOAD_NAME}"; \
+  echo "${PHASH_AMD64_SHA256}  namer/tools/${TARGET_NAME}" | sha256sum -c -; \
+  chmod +x "namer/tools/${TARGET_NAME}"; \
+  ;; \
+  arm64) \
+  # Build from source tarball for the pinned tag (no repo submodule needed)
+  TMPDIR=$(mktemp -d); \
+  curl --fail --silent --show-error --location \
+  --proto '=https' --proto-redir '=https' \
+  -o "$TMPDIR/videohashes.tar.gz" \
+  "https://github.com/peolic/videohashes/tarball/${PHASH_VERSION}"; \
+  echo "${PHASH_ARM64_TAR_SHA256}  $TMPDIR/videohashes.tar.gz" | sha256sum -c -; \
+  mkdir -p "$TMPDIR/src"; \
+  tar -xzf "$TMPDIR/videohashes.tar.gz" -C "$TMPDIR/src" --strip-components=1; \
+  make -C "$TMPDIR/src" linux-arm64; \
+  cp "$TMPDIR/src/dist/videohashes-arm64-linux" ./namer/tools/; \
+  chmod +x ./namer/tools/videohashes-arm64-linux; \
+  # Sanity check the produced binary looks like an aarch64 ELF
+  file ./namer/tools/videohashes-arm64-linux | grep -E 'ELF 64-bit.*aarch64' >/dev/null; \
+  rm -rf "$TMPDIR"; \
+  ;; \
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+  esac; \
+  ls -l namer/tools
 RUN bash -lc "( cd /work/ && poetry run poe build_namer )"
 
 FROM base
@@ -157,7 +157,7 @@ FROM base
 # Install the built namer package globally
 COPY --from=build /work/dist/namer-*.tar.gz /
 RUN pip3 install --break-system-packages /namer-*.tar.gz \
-    && rm /namer-*.tar.gz
+  && rm /namer-*.tar.gz
 
 # Install Intel GPU firmware from host if available, otherwise use a fallback
 # This step installs firmware to support Intel Arc, UHD Graphics, and other Intel GPUs
@@ -174,22 +174,22 @@ RUN chmod +x /usr/local/bin/detect-gpu.sh
 ARG PUID=99
 ARG PGID=100
 RUN set -eux; \
-    if getent group "$PGID" >/dev/null; then \
-      grpname="$(getent group "$PGID" | cut -d: -f1)"; \
-      groupmod -n namer "$grpname" 2>/dev/null || true; \
-    else \
-      groupadd -g "$PGID" namer; \
-    fi; \
-    if getent passwd "$PUID" >/dev/null; then \
-      usrname="$(getent passwd "$PUID" | cut -d: -f1)"; \
-      usermod -l namer "$usrname" 2>/dev/null || true; \
-      usermod -g "$PGID" namer 2>/dev/null || true; \
-    else \
-      useradd -m -u "$PUID" -g "$PGID" namer; \
-    fi; \
-    mkdir -p /database /cache /tmp/namer; \
-    chown -R namer:namer /database /cache /tmp/namer; \
-    chmod 775 /database /cache /tmp/namer
+  if getent group "$PGID" >/dev/null; then \
+  grpname="$(getent group "$PGID" | cut -d: -f1)"; \
+  groupmod -n namer "$grpname" 2>/dev/null || true; \
+  else \
+  groupadd -g "$PGID" namer; \
+  fi; \
+  if getent passwd "$PUID" >/dev/null; then \
+  usrname="$(getent passwd "$PUID" | cut -d: -f1)"; \
+  usermod -l namer "$usrname" 2>/dev/null || true; \
+  usermod -g "$PGID" namer 2>/dev/null || true; \
+  else \
+  useradd -m -u "$PUID" -g "$PGID" namer; \
+  fi; \
+  mkdir -p /database /cache /tmp/namer; \
+  chown -R namer:namer /database /cache /tmp/namer; \
+  chmod 775 /database /cache /tmp/namer
 
 ARG BUILD_DATE
 ARG GIT_HASH  

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,8 @@ RUN bash -lc "( Xvfb :99 & cd /work/ && poetry run poe build_deps )"
 ARG PHASH_VERSION=2025.09.09
 # SHA256 for amd64 asset at the pinned tag (videohashes-linux-amd64)
 ARG PHASH_AMD64_SHA256=dbcc09bd45e260f09dd385e329b041e359fff3bfe66be767070918d519e6f476
+# SHA256 for arm64 source tarball at the pinned tag
+ARG PHASH_ARM64_TAR_SHA256=9fa44b290bc32b8173a2efe08f27d4272406b7583de0a6daa72258e42afc2b3f
 RUN set -eux; \
     cd /work; \
     mkdir -p namer/tools; \
@@ -130,15 +132,12 @@ RUN set -eux; \
         ;; \
       arm64) \
         # Build from source tarball for the pinned tag (no repo submodule needed)
-        # Note: GitHub generates tarballs dynamically, so SHA256 verification is not feasible.
-        # Security is ensured by: 1) HTTPS with CA cert validation, 2) pinned version tag
         TMPDIR=$(mktemp -d); \
         curl --fail --silent --show-error --location \
              --proto '=https' --proto-redir '=https' \
              -o "$TMPDIR/videohashes.tar.gz" \
              "https://github.com/peolic/videohashes/tarball/${PHASH_VERSION}"; \
-        # Verify the tarball was downloaded and is not empty
-        test -s "$TMPDIR/videohashes.tar.gz" || exit 1; \
+        echo "${PHASH_ARM64_TAR_SHA256}  $TMPDIR/videohashes.tar.gz" | sha256sum -c -; \
         mkdir -p "$TMPDIR/src"; \
         tar -xzf "$TMPDIR/videohashes.tar.gz" -C "$TMPDIR/src" --strip-components=1; \
         make -C "$TMPDIR/src" linux-arm64; \

--- a/Makefile
+++ b/Makefile
@@ -128,10 +128,11 @@ pull: ## Pull image from registry
 
 # Developer setup
 setup-dev: ## Bootstrap Poetry + deps, then install local hooks (pre-commit + pre-push)
-	@echo "Checking Poetry availability..."
-	@command -v poetry >/dev/null 2>&1 || (command -v pipx >/dev/null 2>&1 && pipx install poetry || (echo "Poetry not found. Install via pipx (brew install pipx && pipx ensurepath) or pip (pip install --user poetry)" && exit 1))
-	@poetry --version
-	@echo "Installing project dependencies with Poetry..."
-	@poetry install
-	@chmod +x scripts/install-hooks.sh || true
-	@./scripts/install-hooks.sh
+	@set -e; \
+	echo "Checking Poetry availability..."; \
+	command -v poetry >/dev/null 2>&1 || (command -v pipx >/dev/null 2>&1 && pipx install poetry || (echo "Poetry not found. Install via pipx (brew install pipx && pipx ensurepath) or pip (pip install --user poetry)" && exit 1)); \
+	poetry --version; \
+	echo "Installing project dependencies with Poetry..."; \
+	poetry install; \
+	chmod +x scripts/install-hooks.sh || true; \
+	./scripts/install-hooks.sh

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,20 @@ pull: ## Pull image from registry
 
 # Developer setup
 setup-dev: ## Bootstrap Poetry + deps, then install local hooks (pre-commit + pre-push)
-	@set -e; \
-	echo "Checking Poetry availability..."; \
-	command -v poetry >/dev/null 2>&1 || (command -v pipx >/dev/null 2>&1 && pipx install poetry || (echo "Poetry not found. Install via pipx (brew install pipx && pipx ensurepath) or pip (pip install --user poetry)" && exit 1)); \
-	poetry --version; \
-	echo "Installing project dependencies with Poetry..."; \
-	poetry install; \
-	chmod +x scripts/install-hooks.sh || true; \
-	./scripts/install-hooks.sh
+	@bash -lc 'set -euo pipefail; \
+	  echo "Checking Poetry availability..."; \
+	  export PATH="$$HOME/.local/bin:$$PATH"; \
+	  if ! command -v poetry >/dev/null 2>&1; then \
+	    if command -v pipx >/dev/null 2>&1; then \
+	      pipx install --include-deps poetry; \
+	      hash -r; \
+	    else \
+	      echo "Poetry not found. Install pipx (brew install pipx && pipx ensurepath) or pip (pip install --user poetry)"; \
+	      exit 1; \
+	    fi; \
+	  fi; \
+	  poetry --version; \
+	  echo "Installing project dependencies with Poetry..."; \
+	  poetry install; \
+	  chmod +x scripts/install-hooks.sh || true; \
+	  ./scripts/install-hooks.sh'

--- a/Makefile
+++ b/Makefile
@@ -122,12 +122,16 @@ release-prep: validate build-full test-integration ## Full release preparation
 push: ## Push built image to registry
 	@docker push $(IMAGE_NAME):$(VERSION)
 	@docker push $(IMAGE_NAME):latest
-
 pull: ## Pull image from registry
 	@echo "Pulling $(IMAGE_NAME):$(VERSION)..."
 	@docker pull $(IMAGE_NAME):$(VERSION)
 
 # Developer setup
-setup-dev: ## Install local hooks (pre-commit + pre-push) for fast checks and validation
+setup-dev: ## Bootstrap Poetry + deps, then install local hooks (pre-commit + pre-push)
+	@echo "Checking Poetry availability..."
+	@command -v poetry >/dev/null 2>&1 || (command -v pipx >/dev/null 2>&1 && pipx install poetry || (echo "Poetry not found. Install via pipx (brew install pipx && pipx ensurepath) or pip (pip install --user poetry)" && exit 1))
+	@poetry --version
+	@echo "Installing project dependencies with Poetry..."
+	@poetry install
 	@chmod +x scripts/install-hooks.sh || true
 	@./scripts/install-hooks.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dynamic = ["dependencies"]
 requires-python = ">=3.11,<3.15"
 
 [tool.poetry]
+package-mode = false
 include = [
     { path = "namer/web/public/assets/**/*", format = ["sdist", "wheel"] },
     { path = "namer/web/templates/**/*", format = ["sdist", "wheel"] },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ scipy-stubs = "^1.16"
 exclude = [".git", "__pycache__", "docs/source/conf.py", "old", "build", "dist", "*migrations*", "init", "node_modules"]
 line-length = 320
 indent-width = 4
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.format]
 quote-style = "single"

--- a/scripts/install-intel-firmware-fast.sh
+++ b/scripts/install-intel-firmware-fast.sh
@@ -30,9 +30,20 @@ FIRMWARE_INSTALLED=false
 
 for file in "${FIRMWARE_FILES[@]}"; do
     log "Downloading $file..."
-    if timeout 30 wget -q --connect-timeout=10 --read-timeout=10 -O "/lib/firmware/i915/$file" "$FIRMWARE_BASE/$file" 2>/dev/null; then
-        log "Successfully downloaded $file"
-        FIRMWARE_INSTALLED=true
+    if timeout 30 wget -q \
+        --https-only \
+        --secure-protocol=TLSv1_2 \
+        --max-redirect=3 \
+        --tries=3 \
+        --connect-timeout=10 \
+        --read-timeout=10 \
+        -O "/lib/firmware/i915/$file" "$FIRMWARE_BASE/$file" 2>/dev/null; then
+        if [ -s "/lib/firmware/i915/$file" ]; then
+            log "Successfully downloaded $file"
+            FIRMWARE_INSTALLED=true
+        else
+            log "Downloaded $file but file is empty"
+        fi
     else
         log "Failed to download $file (may not be available)"
     fi
@@ -40,13 +51,8 @@ done
 
 # If downloads failed, create placeholder files
 if ! $FIRMWARE_INSTALLED; then
-    log "Creating placeholder firmware files (last resort)..."
-    mkdir -p /lib/firmware/i915
-    touch /lib/firmware/i915/bmg_dmc.bin
-    touch /lib/firmware/i915/dg2_dmc_ver2_08.bin
-    touch /lib/firmware/i915/dg2_guc_70.bin
-    touch /lib/firmware/i915/dg2_huc_gsc.bin
-    log "Created placeholder firmware files"
+    log "No firmware files downloaded; proceeding without installing placeholders."
+    log "If firmware is required, ensure network access to $FIRMWARE_BASE during build."
 fi
 
 # Set proper permissions

--- a/test/updatejson.sh
+++ b/test/updatejson.sh
@@ -2,8 +2,28 @@
 
 TOKEN=${1}
 
-curl --request GET --get "https://api.metadataapi.net/scenes?q=dorcelclub-2021-12-23-peeping-tom" --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" > ./dc.json
-curl --request GET --get "https://api.metadataapi.net/scenes?q=evil-angel-2022-01-03-carmela-clutch-fabulous-anal-3-way" --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" > ./ea.json
-curl --request GET --get "https://api.metadataapi.net/scenes/1678283" --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" > ./ea.full.json
-curl --request GET --get "https://api.metadataapi.net/scenes?q=brazzers-exxtra-suck-suck-blow" --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" > ./ssb2.json
-curl --request GET --get "https://api.metadataapi.net/movies?q=petite18.Harper%20Red&limit=25" --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" > ./p18.json
+curl --fail --silent --show-error --location \
+     --proto '=https' --proto-redir '=https' \
+     --request GET --get "https://api.metadataapi.net/scenes?q=dorcelclub-2021-12-23-peeping-tom" \
+     --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" \
+     > ./dc.json
+curl --fail --silent --show-error --location \
+     --proto '=https' --proto-redir '=https' \
+     --request GET --get "https://api.metadataapi.net/scenes?q=evil-angel-2022-01-03-carmela-clutch-fabulous-anal-3-way" \
+     --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" \
+     > ./ea.json
+curl --fail --silent --show-error --location \
+     --proto '=https' --proto-redir '=https' \
+     --request GET --get "https://api.metadataapi.net/scenes/1678283" \
+     --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" \
+     > ./ea.full.json
+curl --fail --silent --show-error --location \
+     --proto '=https' --proto-redir '=https' \
+     --request GET --get "https://api.metadataapi.net/scenes?q=brazzers-exxtra-suck-suck-blow" \
+     --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" \
+     > ./ssb2.json
+curl --fail --silent --show-error --location \
+     --proto '=https' --proto-redir '=https' \
+     --request GET --get "https://api.metadataapi.net/movies?q=petite18.Harper%20Red&limit=25" \
+     --header "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" --header "Accept: application/json" \
+     > ./p18.json


### PR DESCRIPTION
Bundles the videohashes binary within the Docker image to ensure its availability.

- Downloads pre-built binaries for amd64 architecture from GitHub releases.
- Builds the binary from source for arm64 architecture.
- Pins `videohashes` to version 2025.09.09.
- Sets `target-version=py311` in ruff to match `requires-python >=3.11`.
- Fixes `Poetry` package-mode and improves `setup-dev` for developer environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build**
  * Split build into staged, architecture-aware flow for an external tool, added build args and integrity checks, and ensured certificates and binaries are placed before the final package build.

* **Packaging**
  * Added a package-mode flag, expanded included files for distributions, and bumped tooling baseline to Python 3.11.

* **Chores**
  * Bootstrapped dev setup to validate/install Poetry and deps; hardened network fetches and healthchecks (HTTPS, stricter curl/wget); removed placeholder firmware fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->