### PR TITLE
Enhances docker build and adds web UI config

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main, develop ]
     tags: [ 'v*' ]
+  pull_request:
+    branches: [ main, develop ]
 
 env:
   REGISTRY: ghcr.io
@@ -27,6 +29,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Log in to Container Registry
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
       with:
         registry: ${{ env.REGISTRY }}

--- a/namer/configuration.py
+++ b/namer/configuration.py
@@ -474,6 +474,11 @@ class NamerConfig:
     Extra time to sleep in seconds to allow all information to be copied in dir
     """
 
+    queue_limit: int = 0
+    """
+    Maximum number of pending items allowed in the watchdog command queue. 0 disables the limit.
+    """
+
     queue_sleep_time: int = 5
     """
     Sleep time between queue size check
@@ -487,6 +492,26 @@ class NamerConfig:
     # Note: watch_dir/work_dir/failed_dir/dest_dir are intentionally not defined
     # as dataclass fields by default. They are optional settings that may be
     # provided via config file. Tests expect these to be absent on defaults.
+
+    web: bool = False
+    """
+    Enable the embedded web interface when the watchdog runs.
+    """
+
+    port: int = 6980
+    """
+    Listening port for the embedded web interface.
+    """
+
+    host: str = '127.0.0.1'
+    """
+    Host/IP binding for the web interface.
+    """
+
+    web_root: str = ''
+    """
+    Optional URL prefix for the web interface (e.g., when running behind a proxy).
+    """
 
     allow_delete_files: bool = False
     """
@@ -543,7 +568,7 @@ class NamerConfig:
     ffmpeg: FFMpeg = FFMpeg()
     vph: VideoPerceptualHash = StashVideoPerceptualHash()  # type: ignore
     vph_alt: VideoPerceptualHash = VideoPerceptualHash(ffmpeg)
-    re_cleanup: List[Pattern]
+    re_cleanup: List[Pattern] = field(init=False, default_factory=list)
     _PATH_FIELDS: ClassVar[Set[str]] = {'watch_dir', 'work_dir', 'dest_dir', 'failed_dir'}
 
     def __init__(self):

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -1,13 +1,32 @@
 #!/bin/bash
 # Basic/integration test runner used by Makefile
 # Usage: test-docker.sh <image_name> <version> <basic|integration>
+# Environment variables:
+#   REGISTRY    Optional registry prefix (defaults to ghcr.io when image name lacks registry)
 set -Eeuo pipefail
 
 IMAGE_NAME="${1:-nehpz/namer}"
 VERSION="${2:-latest}"
 MODE="${3:-basic}"
+REGISTRY="${REGISTRY:-ghcr.io}"
 
-IMAGE_REF="${IMAGE_NAME}:${VERSION}"
+prefix_image_with_registry() {
+  local image="$1"
+  local registry="$2"
+
+  if [[ "$image" == */* ]]; then
+    local first_segment="${image%%/*}"
+    if [[ "$first_segment" == *.* || "$first_segment" == *:* ]]; then
+      echo "$image"
+      return
+    fi
+  fi
+
+  echo "${registry}/${image}"
+}
+
+IMAGE_WITH_REGISTRY="$(prefix_image_with_registry "$IMAGE_NAME" "$REGISTRY")"
+IMAGE_REF="${IMAGE_WITH_REGISTRY}:${VERSION}"
 
 log() { echo "[test-docker] $*"; }
 


### PR DESCRIPTION
- Adds pull request trigger to docker build workflow.
- Skips container registry login for pull requests.
- Introduces configuration options for a web UI.
- Allows setting a queue limit for the watchdog.
- Fixes an issue where re_cleanup was not initialized as a list.
- Updates the docker test script to handle image names with and without registries correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added configurable web options: enable/disable web mode, host, port, and web root.
  * Introduced a queue limit setting to control pending tasks.
  * Improved default cleanup behavior for more reliable runtime defaults.
* Chores
  * CI now runs on pull requests and skips container registry login for PRs.
  * Docker build/test scripts support overriding the container registry and handle image references more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->