### PR TITLE
Adds phash uniqueness threshold config

### DIFF
--- a/namer/comparison_results.py
+++ b/namer/comparison_results.py
@@ -198,6 +198,8 @@ class LookedUpFileInfo:
         self.tags = []
         self.hashes = []
         self.original_parsed_filename = FileInfo()
+        self.original_query = None
+        self.original_response = None
 
     def _get_female_performers(self) -> List[Performer]:
         """

--- a/namer/configuration.py
+++ b/namer/configuration.py
@@ -429,6 +429,17 @@ class NamerConfig:
     If there is a PHASH match, require any name match be in the top N results
     """
 
+    phash_unique_threshold: float = 1.0
+    """
+    When multiple scene identifiers are returned for a PHASH/OSHASH match, accept the
+    best candidate only if the most frequent identifier accounts for at least this
+    fraction of all returned identifiers. Example values:
+
+    * 1.0 -> strict uniqueness (only accept when every match points to the same scene)
+    * 0.8 -> accept when a single scene represents 80% or more of returned identifiers
+    * 0.5 -> accept when simple majority (>50%) agrees on the same scene
+    """
+
     ignored_dir_regex: Pattern = re.compile(r'.*_UNPACK_.*', re.IGNORECASE)
     """
     If a file found in the watch dir matches this regex it will be ignored, useful for some file processes.
@@ -692,6 +703,7 @@ class NamerConfig:
                 'ffmpeg_hwaccel_backend': self.ffmpeg_hwaccel_backend or '',
                 'ffmpeg_hwaccel_device': self.ffmpeg_hwaccel_device or '',
                 'ffmpeg_hwaccel_decoder': self.ffmpeg_hwaccel_decoder or '',
+                'phash_unique_threshold': self.phash_unique_threshold,
                 'phash_accept_distance': self.phash_accept_distance,
                 'phash_ambiguous_min': self.phash_ambiguous_min,
                 'phash_ambiguous_max': self.phash_ambiguous_max,

--- a/namer/configuration_utils.py
+++ b/namer/configuration_utils.py
@@ -284,7 +284,12 @@ def from_path(value: Optional[Path]) -> str:
 
 
 def to_float(value: Optional[str]) -> Optional[float]:
-    return float(value) if value is not None else None
+    if value is None:
+        return None
+    value = value.strip()
+    if value == '':
+        return None
+    return float(value)
 
 
 def from_float(value: Optional[float]) -> str:
@@ -393,20 +398,17 @@ field_info: Dict[str, Tuple[str, Optional[Callable[[Optional[str]], Any]], Optio
     'phash_ambiguous_max': ('Phash', to_int, from_int),
     'phash_distance_margin_accept': ('Phash', to_int, from_int),
     'phash_majority_accept_fraction': ('Phash', to_float, from_float),
+    'phash_unique_threshold': ('Phash', to_float, from_float),
     'max_ffmpeg_workers': ('Phash', to_int, from_int),
     'use_gpu': ('Phash', to_bool, from_bool),
     'ffmpeg_hwaccel_backend': ('Phash', None, None),
     'ffmpeg_hwaccel_device': ('Phash', None, None),
     'ffmpeg_hwaccel_decoder': ('Phash', None, None),
-    'mark_collected': ('metadata', to_bool, from_bool),
-    'write_nfo': ('metadata', to_bool, from_bool),
-    'enabled_tagging': ('metadata', to_bool, from_bool),
     'enabled_poster': ('metadata', to_bool, from_bool),
     'download_type': ('metadata', to_str_list_lower, from_str_list_lower),
     'image_format': ('metadata', None, None),
     'enable_metadataapi_genres': ('metadata', to_bool, from_bool),
     'default_genre': ('metadata', None, None),
-    'language': ('metadata', None, None),
     'preserve_duplicates': ('duplicates', to_bool, from_bool),
     'max_desired_resolutions': ('duplicates', to_int, from_int),
     'desired_codec': ('duplicates', to_str_list_lower, from_str_list_lower),

--- a/namer/configuration_utils.py
+++ b/namer/configuration_utils.py
@@ -56,6 +56,12 @@ def validate_disambiguation_config(config: NamerConfig) -> bool:
             config.phash_majority_accept_fraction,
         )
         ok = False
+    if config.phash_unique_threshold is None or not (0.0 <= config.phash_unique_threshold <= 1.0):
+        logger.error(
+            'phash_unique_threshold must be within [0.0, 1.0], got {}',
+            config.phash_unique_threshold,
+        )
+        ok = False
     # Distance relationships
     if config.phash_accept_distance >= config.phash_ambiguous_min:
         logger.error(

--- a/namer/namer.cfg.default
+++ b/namer/namer.cfg.default
@@ -175,6 +175,9 @@ phash_ambiguous_min = 7
 phash_ambiguous_max = 12
 phash_distance_margin_accept = 3
 phash_majority_accept_fraction = 0.7
+# When multiple scene IDs are returned for a hash match, accept the top candidate only if it
+# accounts for at least this fraction of the returned IDs. 1.0 enforces strict uniqueness.
+phash_unique_threshold = 1.0
 
 # Should phashes be sent to tpdb if no phash match was found but a name match was.
 # Requires search_phash be true or is ignored.


### PR DESCRIPTION
Introduces a configuration option to control how strictly to enforce uniqueness when multiple scene identifiers are returned for a PHASH/OSHASH match.  Allows specifying a minimum fraction of matching identifiers required to accept the most frequent candidate. This provides finer-grained control over the accuracy of PHASH matching. Also adds some debug info to the LookedUpFileInfo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a configurable phash_unique_threshold to control how confidently a top hash match must dominate to be accepted; exposed in defaults and config output.
  - Phash matching now uses a consensus/majority decision path based on the threshold to resolve ambiguous hash results.
- Bug Fixes
  - Initialized missing lookup fields to avoid runtime errors.
  - Numeric config parsing now tolerates empty/whitespace inputs.
- Refactor
  - Removed deprecated metadata options from public configuration mappings.
- Tests
  - Added tests covering phash threshold accept/reject behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->