### PR TITLE
fix: resolve dict key mismatch and misleading docstring (P1 issues)

### DIFF
--- a/namer/command.py
+++ b/namer/command.py
@@ -120,7 +120,7 @@ def move_command_files(target: Optional[Command], new_target: Path, is_auto: boo
 def _json_safe(value):
     """
     Convert value to JSON-safe type, handling common non-JSON types explicitly.
-    Raises exceptions for truly problematic types rather than silently returning them.
+    Unknown types are logged as warnings and converted to strings.
     """
     if isinstance(value, dict):
         return {key: _json_safe(val) for key, val in value.items()}

--- a/namer/namer.py
+++ b/namer/namer.py
@@ -63,7 +63,14 @@ def write_ambiguous_metadata(
     # Build candidate details with scene names
     candidates_with_names = []
     if search_results:
-        guid_to_name = {(r.looked_up.guid or r.looked_up.uuid): r.looked_up.name for r in search_results.results if r.looked_up and (r.looked_up.guid or r.looked_up.uuid) and r.looked_up.name}
+        # Build dict with both guid AND uuid as keys to handle both lookup strategies
+        guid_to_name = {}
+        for r in search_results.results:
+            if r.looked_up and r.looked_up.name:
+                if r.looked_up.guid:
+                    guid_to_name[r.looked_up.guid] = r.looked_up.name
+                if r.looked_up.uuid:
+                    guid_to_name[r.looked_up.uuid] = r.looked_up.name
         for guid in candidate_ids:
             candidates_with_names.append({'guid': guid, 'name': guid_to_name.get(guid, 'Unknown')})
 


### PR DESCRIPTION
## Summary

Addresses **P1 (Should-Fix) code quality issues** identified in CodeRabbit review of PR #121.

## Changes

### 1. Fix Dictionary Key Mismatch (`namer/namer.py:66`)

**Problem:**
- `guid_to_name` dict used `(guid or uuid)` as key
- Lookups only used `guid` 
- When `guid` is falsy but `uuid` exists → lookup fails → shows "Unknown"

**Solution:**
- Populate dict with BOTH `guid` AND `uuid` as separate keys
- Ensures lookups succeed whether using `guid` or `uuid`

### 2. Update Misleading Docstring (`namer/command.py:119-124`)

**Problem:**
- `_json_safe()` docstring claimed it "raises exceptions"
- Reality: Unknown types converted to string with warning (line 158-159)

**Solution:**
- Update docstring to match actual behavior: "Unknown types are logged as warnings and converted to strings"

## Testing

- ✅ Pre-commit hooks passed (mypy, pytest fast tests, ruff)
- ✅ No breaking changes - backward compatible improvements

## Related

- Part of work extracted from `feature/improve-dev-tooling` 
- Addresses CodeRabbit P1 feedback from PR #121
- Improves code correctness and documentation accuracy