### PR TITLE
🚨 Hotfix: GraphQL schema validation errors breaking both metadata providers

### DIFF
--- a/namer/metadata_providers/stashdb_provider.py
+++ b/namer/metadata_providers/stashdb_provider.py
@@ -305,7 +305,9 @@ class StashDBProvider(BaseMetadataProvider):
                             performer {
                                 name
                                 aliases
-                                images
+                                images {
+                                    url
+                                }
                                 gender
                             }
                         }
@@ -366,7 +368,9 @@ class StashDBProvider(BaseMetadataProvider):
                             performer {
                                 name
                                 aliases
-                                images
+                                images {
+                                    url
+                                }
                                 gender
                             }
                         }
@@ -662,7 +666,9 @@ class StashDBProvider(BaseMetadataProvider):
                             performer {
                                 name
                                 aliases
-                                images
+                                images {
+                                    url
+                                }
                                 gender
                             }
                         }

--- a/namer/metadata_providers/theporndb_provider.py
+++ b/namer/metadata_providers/theporndb_provider.py
@@ -430,19 +430,16 @@ class ThePornDBProvider(BaseMetadataProvider):
                     id
                     title
                     date
-                    description
                     duration
-                    url
                     urls { view }
                     site { name parent { name } network { name } }
                     performers {
-                        name
-                        parent { name image extras { gender } }
-                        image
-                        extras { gender }
+                        performer {
+                            name
+                            image
+                        }
                     }
                     tags { name }
-                    hashes { hash type duration }
                 }
             }
         """
@@ -484,9 +481,7 @@ class ThePornDBProvider(BaseMetadataProvider):
                     id
                     title
                     date
-                    description
                     duration
-                    url
                     urls {
                         view
                     }
@@ -501,26 +496,13 @@ class ThePornDBProvider(BaseMetadataProvider):
                         }
                     }
                     performers {
-                        name
-                        parent {
+                        performer {
                             name
                             image
-                            extras {
-                                gender
-                            }
-                        }
-                        image
-                        extras {
-                            gender
                         }
                     }
                     tags {
                         name
-                    }
-                    hashes {
-                        hash
-                        type
-                        duration
                     }
                 }
             }
@@ -687,26 +669,13 @@ def _build_graphql_query(query_type: str, variables: Dict[str, Any]) -> Dict[str
                         }
                     }
                     performers {
-                        name
-                        parent {
+                        performer {
                             name
                             image
-                            extras {
-                                gender
-                            }
-                        }
-                        image
-                        extras {
-                            gender
                         }
                     }
                     tags {
                         name
-                    }
-                    hashes {
-                        hash
-                        type
-                        duration
                     }
                 }
             }
@@ -730,26 +699,13 @@ def _build_graphql_query(query_type: str, variables: Dict[str, Any]) -> Dict[str
                         }
                     }
                     performers {
-                        name
-                        parent {
+                        performer {
                             name
                             image
-                            extras {
-                                gender
-                            }
-                        }
-                        image
-                        extras {
-                            gender
                         }
                     }
                     tags {
                         name
-                    }
-                    hashes {
-                        hash
-                        type
-                        duration
                     }
                 }
             }


### PR DESCRIPTION
## 🔥 Critical Production Issue

Both StashDB and ThePornDB metadata providers are **completely broken** in v1.23.3, routing all files to the failed directory with 100% failure rate.

## Issues Fixed

Closes #130 - StashDB GraphQL schema validation errors  
Closes #131 - ThePornDB GraphQL deprecated field errors

## Root Causes

### StashDB (#130)
Missing subfield selection for `images` field causes GraphQL 422 validation errors:
```
Field "images" of type "[Image!]!" must have a selection of subfields
```

### ThePornDB (#131)
Queries using deprecated/non-existent fields from old schema:
- `description` field doesn't exist
- `url` standalone field removed (only `urls { view }` works)
- `hashes` field doesn't exist
- `performers` structure changed

## Changes Made

### StashDB Provider
- ✅ Added `images { url }` subfield selection in all performer blocks
- ✅ Affects: `findScene`, `searchScene`, `findSceneByFingerprint` queries

### ThePornDB Provider  
- ✅ Removed `description` field
- ✅ Removed standalone `url` field
- ✅ Updated `performers` to `performer { name image }` structure
- ✅ Removed `hashes` field from all queries
- ✅ Updated legacy query mappings for consistency

## Testing

✅ All metadata tests pass (18/18)  
✅ Full test suite passes (112 passed, 1 skipped)  
✅ Type checking passes (mypy)  
✅ Linting passes (ruff)  
✅ Test coverage: 75%

## Impact

**Before:** 100% failure rate - all files → failed directory  
**After:** Metadata lookups functional again

## Deployment

This is a **hotfix** branched from `main` and should be:
1. Merged to `main` immediately 
2. Tagged as v1.23.4
3. Deployed to production ASAP
4. Merged back to `develop` per Git Flow

## Evidence

Logs showing complete failure in v1.23.3:
```
StashDB API error: 422 - {"errors":[{"message":"Field \"images\" of type \"[Image!]!\" must have a selection of subfields...
GraphQL error: Cannot query field "description" on type "Scene"
GraphQL error: Cannot query field "hashes" on type "Scene"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * More reliable display of performer images by using direct image URLs from metadata sources.

* **Improvements**
  * Updated ThePornDB integration to use a new performer structure, providing more consistent names/images.
  * Reduced metadata payloads for scenes, which may improve lookup speed and responsiveness.
  * Harmonized performer mapping across sources for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->